### PR TITLE
Namespacing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
+gem 'rake'
 gem 'sprockets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     rack (1.6.1)
+    rake (11.1.2)
     sprockets (3.1.0)
       rack (~> 1.0)
 
@@ -9,7 +10,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rake
   sprockets
 
 BUNDLED WITH
-   1.10.3
+   1.11.2

--- a/lib/viking/support/string.js
+++ b/lib/viking/support/string.js
@@ -24,19 +24,19 @@ String.prototype.humanize = function() {
 
 // Makes an underscored, lowercase form from the expression in the string.
 //
-// Changes '::' to '/' to convert namespaces to paths.
+// Changes '.' to '/' to convert namespaces to paths.
 //
 // Examples:
 // 
 //     "ActiveModel".underscore         # => "active_model"
-//     "ActiveModel::Errors".underscore # => "active_model/errors"
+//     "ActiveModel.Errors".underscore # => "active_model/errors"
 //
 // As a rule of thumb you can think of underscore as the inverse of camelize,
 // though there are cases where that does not hold:
 //
 //     "SSLError".underscore().camelize() # => "SslError"
 String.prototype.underscore = function() {
-    var result = this.replace('::', '/');
+    var result = this.replace('.', '/');
     result = result.replace(/([A-Z\d]+)([A-Z][a-z])/g, "$1_$2");
     result = result.replace(/([a-z\d])([A-Z])/g, "$1_$2");
     return result.replace('-', '_').toLowerCase();
@@ -45,7 +45,7 @@ String.prototype.underscore = function() {
 // By default, #camelize converts strings to UpperCamelCase. If the argument
 // to camelize is set to `false` then #camelize produces lowerCamelCase.
 //
-// \#camelize will also convert "/" to "::" which is useful for converting
+// \#camelize will also convert "/" to "." which is useful for converting
 // paths to namespaces.
 //
 // Examples:
@@ -53,8 +53,8 @@ String.prototype.underscore = function() {
 //     "active_model".camelize               // => "ActiveModel"
 //     "active_model".camelize(true)         // => "ActiveModel"
 //     "active_model".camelize(false)        // => "activeModel"
-//     "active_model/errors".camelize        // => "ActiveModel::Errors"
-//     "active_model/errors".camelize(false) // => "activeModel::Errors"
+//     "active_model/errors".camelize        // => "ActiveModel.Errors"
+//     "active_model/errors".camelize(false) // => "activeModel.Errors"
 //
 // As a rule of thumb you can think of camelize as the inverse of underscore,
 // though there are cases where that does not hold:
@@ -63,7 +63,7 @@ String.prototype.underscore = function() {
 String.prototype.camelize = function(uppercase_first_letter) {
     var result = uppercase_first_letter === undefined || uppercase_first_letter ? this.capitalize() : this.anticapitalize();
     result = result.replace(/(_|(\/))([a-z\d]*)/g, function(_a, _b, first, rest) { return (first || '') + rest.capitalize(); });
-    return result.replace('/', '::');
+    return result.replace('/', '.');
 };
 
 // Convert a string to a boolean value. If the argument to #booleanize is

--- a/package.json
+++ b/package.json
@@ -12,5 +12,5 @@
     "test": "phantomjs test/runner.js http://127.0.0.1:4321/test/index.html"
   },
   "main"          : "viking.js",
-  "version"       : "0.8.0"
+  "version"       : "0.8.1"
 }

--- a/test/viking/support/string.js
+++ b/test/viking/support/string.js
@@ -26,7 +26,7 @@
 
     test("underscore()", function() {
         equal("ActiveModel".underscore(), "active_model");
-        equal("ActiveModel::Errors".underscore(), "active_model/errors");
+        equal("ActiveModel.Errors".underscore(), "active_model/errors");
         equal("SSLError".underscore(), "ssl_error");
     });
 
@@ -34,9 +34,9 @@
         equal("active_model".camelize(), "ActiveModel");
         equal("active_model".camelize(true), "ActiveModel");
         equal("active_model".camelize(false), "activeModel");
-        equal("active_model/errors".camelize(), "ActiveModel::Errors");
-        equal("active_model/errors".camelize(true), "ActiveModel::Errors");
-        equal("active_model/errors".camelize(false), "activeModel::Errors");
+        equal("active_model/errors".camelize(), "ActiveModel.Errors");
+        equal("active_model/errors".camelize(true), "ActiveModel.Errors");
+        equal("active_model/errors".camelize(false), "activeModel.Errors");
     });
 
     test("booleanize()", function() {

--- a/viking.js
+++ b/viking.js
@@ -1,4 +1,4 @@
-//     Viking.js 0.8.0 (sha:2f87adc)
+//     Viking.js 0.8.1 (sha:af2905f)
 //
 //     (c) 2012-2016 Jonathan Bracy, 42Floors Inc.
 //     Viking.js may be freely distributed under the MIT license.
@@ -261,19 +261,19 @@ String.prototype.humanize = function() {
 
 // Makes an underscored, lowercase form from the expression in the string.
 //
-// Changes '::' to '/' to convert namespaces to paths.
+// Changes '.' to '/' to convert namespaces to paths.
 //
 // Examples:
 // 
 //     "ActiveModel".underscore         # => "active_model"
-//     "ActiveModel::Errors".underscore # => "active_model/errors"
+//     "ActiveModel.Errors".underscore # => "active_model/errors"
 //
 // As a rule of thumb you can think of underscore as the inverse of camelize,
 // though there are cases where that does not hold:
 //
 //     "SSLError".underscore().camelize() # => "SslError"
 String.prototype.underscore = function() {
-    var result = this.replace('::', '/');
+    var result = this.replace('.', '/');
     result = result.replace(/([A-Z\d]+)([A-Z][a-z])/g, "$1_$2");
     result = result.replace(/([a-z\d])([A-Z])/g, "$1_$2");
     return result.replace('-', '_').toLowerCase();
@@ -282,7 +282,7 @@ String.prototype.underscore = function() {
 // By default, #camelize converts strings to UpperCamelCase. If the argument
 // to camelize is set to `false` then #camelize produces lowerCamelCase.
 //
-// \#camelize will also convert "/" to "::" which is useful for converting
+// \#camelize will also convert "/" to "." which is useful for converting
 // paths to namespaces.
 //
 // Examples:
@@ -290,8 +290,8 @@ String.prototype.underscore = function() {
 //     "active_model".camelize               // => "ActiveModel"
 //     "active_model".camelize(true)         // => "ActiveModel"
 //     "active_model".camelize(false)        // => "activeModel"
-//     "active_model/errors".camelize        // => "ActiveModel::Errors"
-//     "active_model/errors".camelize(false) // => "activeModel::Errors"
+//     "active_model/errors".camelize        // => "ActiveModel.Errors"
+//     "active_model/errors".camelize(false) // => "activeModel.Errors"
 //
 // As a rule of thumb you can think of camelize as the inverse of underscore,
 // though there are cases where that does not hold:
@@ -300,7 +300,7 @@ String.prototype.underscore = function() {
 String.prototype.camelize = function(uppercase_first_letter) {
     var result = uppercase_first_letter === undefined || uppercase_first_letter ? this.capitalize() : this.anticapitalize();
     result = result.replace(/(_|(\/))([a-z\d]*)/g, function(_a, _b, first, rest) { return (first || '') + rest.capitalize(); });
-    return result.replace('/', '::');
+    return result.replace('/', '.');
 };
 
 // Convert a string to a boolean value. If the argument to #booleanize is


### PR DESCRIPTION
Adding support for namespaced models.

For example, the following model name should resolve to the correct constant:

var Integrations.Plaid.Account =
Viking.Model.extend('integrations/plaid/account', { });