### PR TITLE
Fix: select method minor fix

### DIFF
--- a/lib/viking/model/instance_properties/select.js
+++ b/lib/viking/model/instance_properties/select.js
@@ -31,6 +31,7 @@ Viking.Model.prototype.select = function(value, options) {
         if (this.selected) {
             this.selected = false;
             this.trigger('unselected', this);
+            if (this.collection) this.collection.trigger('unselected', this);
         }
     }
 };


### PR DESCRIPTION
Triggers an `unselected` event on the collection if the collection exists.