### PR TITLE
add events to record when it is added or removed from an association

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -35,6 +35,16 @@ import { Reflection } from './record/reflection';
 // Viking.Model is an extension of [Backbone.Model](http://backbonejs.org/#Model).
 // It adds naming, relationships, data type coercions, selection, and modifies
 // sync to work with [Ruby on Rails](http://rubyonrails.org/) out of the box.
+//
+// Events
+// ------
+//  |event|description|arguments|
+//  |-----|-----------|---------|
+//  |add|record has been added to an association|association|
+//  |remove|record has been removed from an association|association|
+//  |change|record has been changed|record|
+//  |change:[attribute]|record attribute has been changed|record, new value|
+//  |*|any event|event_name, ...arguments|
 export default class Record extends EventBus {
 
     static connection = null; // : Connection | null = null;

--- a/lib/viking/record/associations/belongsToAssociation.js
+++ b/lib/viking/record/associations/belongsToAssociation.js
@@ -11,15 +11,15 @@ export default class BelongsToAssociation extends Association {
         this.target = target;
         this.loaded = true;
 
-        if (target !== null && target !== undefined && target.primaryKey()) {
-            this.owner.setAttributes({
-                [this.reflection.foreignKey()]: target.primaryKey()
-            });
-        } 
+        this.owner.setAttributes({
+            [this.reflection.foreignKey()]: target ? target.primaryKey() : null
+        });
         if (target) {
             this.dispatchEvent('add', target);
+            target.dispatchEvent('add', this);
         } else {
             this.dispatchEvent('remove', oldTarget);
+            oldTarget?.dispatchEvent('remove', this);
         }
     }
     

--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -29,9 +29,16 @@ export default class CollectionAssociation extends Association {
         
         if(addedRecords.length > 0) {
             this.dispatchEvent('add', addedRecords)
+            addedRecords.forEach(x => x.dispatchEvent('add', this))
         }
         if(removedRecords.length > 0) {
             this.dispatchEvent('remove', removedRecords)
+            removedRecords.forEach(x => {
+                x.setAttributes({
+                    [this.foreignKey()]: this.owner.readAttribute(this.primaryKey())
+                });
+                x.dispatchEvent('remove', this)
+            })
         }
 
         this.loaded = true;

--- a/lib/viking/record/associations/hasOneAssociation.js
+++ b/lib/viking/record/associations/hasOneAssociation.js
@@ -11,16 +11,18 @@ export default class HasOneAssociation extends Association {
         this.target = target;
         this.loaded = true;
 
-        if (target !== null && target !== undefined && this.owner.primaryKey()) {
+        if(target){
             target.setAttributes({
                 [this.reflection.foreignKey()]: this.owner.primaryKey()
             });
-        }
-        
-        if(target){
             this.dispatchEvent('add', target)
+            target.dispatchEvent('add', this)
         } else {
+            oldTarget?.setAttributes({
+                [this.reflection.foreignKey()]: null
+            });
             this.dispatchEvent('remove', oldTarget)
+            oldTarget?.dispatchEvent('remove', this)
         }
     }
 

--- a/lib/viking/record/associations/hasOneAssociation.js
+++ b/lib/viking/record/associations/hasOneAssociation.js
@@ -11,7 +11,7 @@ export default class HasOneAssociation extends Association {
         this.target = target;
         this.loaded = true;
 
-        if(target){
+        if (target) {
             target.setAttributes({
                 [this.reflection.foreignKey()]: this.owner.primaryKey()
             });

--- a/test/record/associations/events/belongsToEventTest.js
+++ b/test/record/associations/events/belongsToEventTest.js
@@ -23,6 +23,19 @@ describe('Viking.Record::ssociations', () => {
             model.parent = parent
         })
         
+        it("setting target fires add event on record", function (done){
+            let model = new Model();
+            let parent = new Parent({id: 24});
+        
+            parent.addEventListener('add', association => {
+                assert.equal(association.owner, model);
+                assert.equal(model.readAttribute('parent_id'), 24)
+                done()
+            })
+        
+            model.parent = parent
+        })
+        
         it("unsetting target fires remove event", function (done) {
             let model = new Model();
             let parent = new Parent({id: 24});
@@ -30,6 +43,20 @@ describe('Viking.Record::ssociations', () => {
             
             model.association('parent').addEventListener('remove', record => {
                 assert.equal(record.readAttribute('id'), 24)
+                done()
+            })
+            
+            model.parent = null
+        })
+        
+        it("unsetting target fires remove event on record", function (done) {
+            let model = new Model();
+            let parent = new Parent({id: 24});
+            model.parent = parent
+            
+            parent.addEventListener('remove', association => {
+                assert.equal(association.owner, model);
+                assert.equal(model.readAttribute('parent_id'), null)
                 done()
             })
             

--- a/test/record/associations/events/hasAndBelongsToManyEventTest.js
+++ b/test/record/associations/events/hasAndBelongsToManyEventTest.js
@@ -23,6 +23,18 @@ describe('Viking.Record::ssociations', () => {
             model.parents = [parent]
         })
         
+        it("setting target fires add event on record", function (done){
+            let model = new Model({id: 11});
+            let parent = new Parent({id: 24});
+        
+            parent.addEventListener('add', association => {
+                assert.equal(association.owner, model)
+                done()
+            })
+        
+            model.parents.push(parent)
+        })
+        
         it("unsetting target fires remove event", function (done) {
             let model = new Model();
             let parent = new Parent({id: 24});
@@ -30,6 +42,19 @@ describe('Viking.Record::ssociations', () => {
             
             model.association('parents').addEventListener('remove', records => {
                 assert.equal(records[0].readAttribute('id'), 24)
+                done()
+            })
+            
+            model.parents = []
+        })
+        
+        it("unsetting target fires remove event on record", function (done) {
+            let model = new Model();
+            let parent = new Parent({id: 24});
+            model.parents = [parent]
+            
+            parent.addEventListener('remove', association => {
+                assert.equal(association.owner, model)
                 done()
             })
             

--- a/test/record/associations/events/hasManyEventTest.js
+++ b/test/record/associations/events/hasManyEventTest.js
@@ -23,6 +23,19 @@ describe('Viking.Record::ssociations', () => {
             model.parents.push(parent)
         })
         
+        it("setting target fires add event on record", function (done){
+            let model = new Model({id: 11});
+            let parent = new Parent({id: 24});
+        
+            parent.addEventListener('add', association => {
+                assert.equal(association.owner, model)
+                assert.equal(parent.readAttribute('model_id'), 11)
+                done()
+            })
+        
+            model.parents.push(parent)
+        })
+        
         it("unsetting target fires remove event", function (done) {
             let model = new Model();
             let parent = new Parent({id: 24});
@@ -30,6 +43,20 @@ describe('Viking.Record::ssociations', () => {
             
             model.association('parents').addEventListener('remove', records => {
                 assert.equal(records[0].readAttribute('id'), 24)
+                done()
+            })
+            
+            model.parents = []
+        })
+        
+        it("unsetting target fires remove event on record", function (done) {
+            let model = new Model();
+            let parent = new Parent({id: 24});
+            model.parents = [parent]
+            
+            parent.addEventListener('remove', association => {
+                assert.equal(association.owner, model)
+                assert.equal(parent.readAttribute('model_id'), null)
                 done()
             })
             

--- a/test/record/associations/events/hasOneEventTest.js
+++ b/test/record/associations/events/hasOneEventTest.js
@@ -23,6 +23,19 @@ describe('Viking.Record::ssociations', () => {
             model.parent = parent
         })
         
+        it("setting target fires add event on record", function (done){
+            let model = new Model({id: 11});
+            let parent = new Parent({id: 24});
+        
+            parent.addEventListener('add', association => {
+                assert.equal(association.owner, model);
+                assert.equal(parent.readAttribute('model_id'), 11)
+                done()
+            })
+        
+            model.parent = parent
+        })
+        
         it("unsetting target fires remove event", function (done) {
             let model = new Model();
             let parent = new Parent({id: 24});
@@ -30,6 +43,20 @@ describe('Viking.Record::ssociations', () => {
             
             model.association('parent').addEventListener('remove', record => {
                 assert.equal(record.readAttribute('id'), 24)
+                done()
+            })
+            
+            model.parent = null
+        })
+        
+        it("unsetting target fires remove event on record", function (done) {
+            let model = new Model();
+            let parent = new Parent({id: 24});
+            model.parent = parent
+            
+            parent.addEventListener('remove', association => {
+                assert.equal(association.owner, model);
+                assert.equal(parent.readAttribute('model_id'), null)
                 done()
             })
             


### PR DESCRIPTION
```javascript
let model = new Model({id: 11});
let parent = new Parent({id: 24});

parent.addEventListener('add', association => {
    assert.equal(association.owner, model)
})

model.parents.push(parent)
```