### PR TITLE
add defaultHeaders and csrf-token lookup to connection

### DIFF
--- a/lib/viking/record/connection.js
+++ b/lib/viking/record/connection.js
@@ -7,6 +7,7 @@ export default class Connection {
     host;//: string;
     apiKey;//: string;
     _userAgent;//: string | null;
+    defaultHeaders = {};
 
     // constructor(url: string, options: { userAgent?: string; } = {})
     constructor(url, options = {}) {
@@ -15,6 +16,7 @@ export default class Connection {
         this.host = (origin + pathname).replace(/\/$/, '');
         this.apiKey = username;
         this._userAgent = options.userAgent ? options.userAgent : null;
+        this.defaultHeaders = options.headers;
     }
 
     // Returns the User-Agent of the client. Defaults to:
@@ -66,9 +68,19 @@ export default class Connection {
                 request.setRequestHeader('Content-Type', 'application/json')
             }
             
+            const token = document.querySelector(['meta[name="csrf-token"]'])
+            if (token) {
+                request.setRequestHeader('X-CSRF-Token', token.getAttribute('content'))
+            }
+            
+            each(this.defaultHeaders, (key, value) => {
+                request.setRequestHeader(key, value);
+            });
+
             each(headers, (key, value) => {
                 request.setRequestHeader(key, value);
             });
+
             
             let error_callback = () => {
                 if (request.status === 301) {

--- a/lib/viking/record/connection.js
+++ b/lib/viking/record/connection.js
@@ -7,7 +7,6 @@ export default class Connection {
     host;//: string;
     apiKey;//: string;
     _userAgent;//: string | null;
-    defaultHeaders = {};
 
     // constructor(url: string, options: { userAgent?: string; } = {})
     constructor(url, options = {}) {
@@ -16,7 +15,7 @@ export default class Connection {
         this.host = (origin + pathname).replace(/\/$/, '');
         this.apiKey = username;
         this._userAgent = options.userAgent ? options.userAgent : null;
-        this.defaultHeaders = options.headers;
+        this.csrfToken = document.head.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
     }
 
     // Returns the User-Agent of the client. Defaults to:
@@ -68,14 +67,9 @@ export default class Connection {
                 request.setRequestHeader('Content-Type', 'application/json')
             }
             
-            const token = document.querySelector(['meta[name="csrf-token"]'])
-            if (token) {
-                request.setRequestHeader('X-CSRF-Token', token.getAttribute('content'))
+            if (this.csrfToken) {
+                request.setRequestHeader('X-CSRF-Token', this.csrfToken);
             }
-            
-            each(this.defaultHeaders, (key, value) => {
-                request.setRequestHeader(key, value);
-            });
 
             each(headers, (key, value) => {
                 request.setRequestHeader(key, value);

--- a/test/record/connectionTest.js
+++ b/test/record/connectionTest.js
@@ -1,0 +1,21 @@
+import 'mocha';
+import * as assert from 'assert';
+import Connection from 'viking/record/connection';
+
+describe('Viking.Record', () => {
+    describe('Connection', () => {
+
+        it('Automatically add the CSRF token', function () {
+            document.head.innerHTML = '<meta name="csrf-token" content="ETZaIMiq">';
+            console.log(document.head.innerHTML);
+                    
+            let connection = new Connection('http://example.com');
+            connection.get('/');
+            
+            this.withRequest('GET', '/', {}, (xhr) => {
+                assert.equal(xhr.requestHeaders['X-CSRF-Token'], "ETZaIMiq");
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
Add `defaultHeaders` to connection options.
```javascript
export default class ApplicationRecord extends VikingRecord {
  static abstract = true;
  static connection = new VikingRecordConnection(window.location.protocol + '//' + window.location.host, {
    headers: {
      'Some-Header': 'some_content'
    }
  }
); 
}
```

Add a lookup to `sendRequest` on `Connection` that looks for `<meta name="csrf-token" content="...">` and uses it as a header if exists.