### PR TITLE
Association Order

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -416,7 +416,6 @@ export default class Record extends EventBus {
         this.coerceAttributes(attributes, (key, value) => {
             if (this._associations.hasOwnProperty(key)) {
                 if (value instanceof Record) {
-                    console.log(this._associations[key]);
                     this._associations[key].setTarget(value);
                 } else {
                     this._associations[key].instantiate(value);

--- a/lib/viking/record/associations/belongsToAssociation.js
+++ b/lib/viking/record/associations/belongsToAssociation.js
@@ -71,8 +71,14 @@ export default class BelongsToAssociation extends Association {
             klass = this.reflection.model;
         }
             
-        return klass.where({
+        let relation = klass.where({
             [klass.primaryKey]: this.owner.readAttribute(this.reflection.foreignKey())
         });
+        
+        if (this.reflection.scope) {
+            relation = this.reflection.scope.call(this.owner, relation);
+        }
+        
+        return relation;
     }
 }

--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -60,7 +60,7 @@ export default class CollectionAssociation extends Association {
                     this.target = records;
                     this.loaded = true;
                     
-                    this.dispatchEvent('loaded', records)
+                    this.dispatchEvent('loaded', records);
                     return records;
                 });
             } else {

--- a/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
+++ b/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
@@ -14,11 +14,16 @@ export default class HasAndBelongsToManyAssociation extends CollectionAssociatio
     
     scope() {
         let klass = this.reflection.model;
-        return klass.where({
+        let relation = klass.where({
             [this.joinTable()]: {
                 [this.foreignKey()]: this.owner.readAttribute(this.primaryKey())
             }
         });
+        
+        if (this.reflection.options?.order) {
+            relation = relation.order(this.reflection.options?.order)
+        }
+        return relation;
     }
 
 }

--- a/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
+++ b/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
@@ -14,15 +14,17 @@ export default class HasAndBelongsToManyAssociation extends CollectionAssociatio
     
     scope() {
         let klass = this.reflection.model;
+        
         let relation = klass.where({
             [this.joinTable()]: {
                 [this.foreignKey()]: this.owner.readAttribute(this.primaryKey())
             }
         });
-        
-        if (this.reflection.options?.order) {
-            relation = relation.order(this.reflection.options?.order)
+
+        if (this.reflection.scope) {
+            relation = this.reflection.scope.call(this.owner, relation);
         }
+        
         return relation;
     }
 

--- a/lib/viking/record/associations/hasManyAssociation.js
+++ b/lib/viking/record/associations/hasManyAssociation.js
@@ -4,9 +4,13 @@ export default class HasManyAssociation extends CollectionAssociation {
 
     scope() {
         let klass = this.reflection.model;
-        return klass.where({
+        let relation = klass.where({
             [this.foreignKey()]: this.owner.readAttribute(this.primaryKey())
-        });
+        })
+        if (this.reflection.options?.order) {
+            relation = relation.order(this.reflection.options?.order)
+        }
+        return relation;
     }
 
 }

--- a/lib/viking/record/associations/hasManyAssociation.js
+++ b/lib/viking/record/associations/hasManyAssociation.js
@@ -4,12 +4,15 @@ export default class HasManyAssociation extends CollectionAssociation {
 
     scope() {
         let klass = this.reflection.model;
+        
         let relation = klass.where({
             [this.foreignKey()]: this.owner.readAttribute(this.primaryKey())
         })
-        if (this.reflection.options?.order) {
-            relation = relation.order(this.reflection.options?.order)
+        
+        if (this.reflection.scope) {
+            relation = this.reflection.scope.call(this.owner, relation);
         }
+
         return relation;
     }
 

--- a/lib/viking/record/associations/hasOneAssociation.js
+++ b/lib/viking/record/associations/hasOneAssociation.js
@@ -52,8 +52,15 @@ export default class HasOneAssociation extends Association {
 
     scope() {
         let klass = this.reflection.model;
-        return klass.where({
+
+        let relation = klass.where({
             [this.reflection.foreignKey()]: this.owner.primaryKey()
         });
+        
+        if (this.reflection.scope) {
+            relation = this.reflection.scope.call(this.owner, relation);
+        }
+        
+        return relation;
     }
 }

--- a/lib/viking/record/reflections/belongsToReflection.js
+++ b/lib/viking/record/reflections/belongsToReflection.js
@@ -1,43 +1,33 @@
-import Model from '../../record';
+import Record from '../../record';
 import Reflection from '../reflection';
 import BelongsToAssociation from '../associations/belongsToAssociation';
 
 // export interface IBelongsToReflectionOptions {
 //     foreignKey?: string;
 //     foreignType?: string;
-//     polymorphic?: typeof Model[];
+//     polymorphic?: typeof Record[];
 // }
 
 export default class BelongsToReflection extends Reflection {
 
     name;//: string;
-    model;//: typeof Model;
+    model;//: typeof Record;
     options;//: IBelongsToReflectionOptions;
 
-    // constructor(model: typeof Model, options?: IBelongsToReflectionOptions);
-    // constructor(name: string, model: Model, options?: IBelongsToReflectionOptions);
+    // constructor(model: typeof Record, options?: IBelongsToReflectionOptions);
+    // constructor(name: string, model: Record, options?: IBelongsToReflectionOptions);
     // constructor(name: string, options: IBelongsToReflectionOptions);
-    constructor(name, model, options) {
+    constructor(name, model, scope, options) {
         super();
-        
-        if (Model.isPrototypeOf(name)) {
-            options = model;
-            model = name;
-            name = model.modelName().singular;
-        } else if (!Model.isPrototypeOf(model)) {
-            options = model;
-            model = undefined;
-        }
-
-
         this.name = name;
         this.macro = 'belongsTo';
         this.model = model || (options ? options.model : undefined);
         this.polymorphic = options ? options.polymorphic : undefined;
+        this.scope = scope;
         this.options = options || {};
     }
 
-    // attachTo(model: Model)
+    // attachTo(model: Record)
     attachTo(model) {
         let association = new BelongsToAssociation(model, this);
 
@@ -93,12 +83,29 @@ export default class BelongsToReflection extends Reflection {
     }
 }
 
-// export function belongsTo(model: typeof Model, options?: IBelongsToReflectionOptions);
-// export function belongsTo(name: string, model: Model, options?: IBelongsToReflectionOptions);
+// export function belongsTo(model: typeof Record, options?: IBelongsToReflectionOptions);
+// export function belongsTo(name: string, model: Record, options?: IBelongsToReflectionOptions);
 // export function belongsTo(name: string, options: IBelongsToReflectionOptions);
-export function belongsTo(name, model, options) {
+export function belongsTo(name, model, scope, options) {
+    if (Record.isPrototypeOf(name)) {
+        options = scope;
+        scope = model;
+        model = name;
+        name = model.modelName().singular;
+    }
+    
+    if (!Record.isPrototypeOf(model)) {
+        options = scope;
+        scope =  model;
+    }
+    
+    if (typeof scope !== 'function') {
+        options = scope;
+        scope = null;
+    }
+
     return {
         reflection: BelongsToReflection,
-        args: [name, model, options]
+        args: [name, model, scope, options]
     };
 }

--- a/lib/viking/record/reflections/hasAndBelongsToManyReflection.js
+++ b/lib/viking/record/reflections/hasAndBelongsToManyReflection.js
@@ -1,4 +1,4 @@
-import Model from '../../record';
+import Record from '../../record';
 import Reflection from '../reflection';
 import HasAndBelongsToManyAssociation from '../associations/hasAndBelongsToManyAssociation';
 
@@ -11,30 +11,22 @@ import HasAndBelongsToManyAssociation from '../associations/hasAndBelongsToManyA
 export default class HasAndBelongsToManyReflection extends Reflection {
 
     name;//: string;
-    model;//: typeof Model;
+    model;//: typeof Record;
     options;//: IHasAndBelongsToManyReflectionOptions;
 
-    // constructor(model: typeof Model, options?: IHasAndBelongsToManyReflectionOptions);
-    // constructor(name: string, model: Model, options?: IHasAndBelongsToManyReflectionOptions);
+    // constructor(model: typeof Record, options?: IHasAndBelongsToManyReflectionOptions);
+    // constructor(name: string, model: Record, options?: IHasAndBelongsToManyReflectionOptions);
     // constructor(name: string, options: IHasAndBelongsToManyReflectionOptions);
-    constructor(name, model, options) {
-        if (Model.isPrototypeOf(name)) {
-            options = model;
-            model = name;
-            name = model.modelName().plural;
-        } else {
-            options = model;
-            model = undefined;
-        }
-
+    constructor(name, model, scope, options) {
         super();
         this.name = name;
         this.macro = 'hasAndBelongsToMany';
         this.model = model;
+        this.scope = scope;
         this.options = options ? options : {};
     }
 
-    // attachTo(model: Model)
+    // attachTo(model: Record)
     attachTo(model) {
         let association = new HasAndBelongsToManyAssociation(model, this);
 
@@ -52,12 +44,24 @@ export default class HasAndBelongsToManyReflection extends Reflection {
 
 }
 
-// export function hasMany(model: typeof Model, options?: IHasAndBelongsToManyReflectionOptions);
-// export function hasMany(name: string, model: Model, options?: IHasAndBelongsToManyReflectionOptions);
+// export function hasMany(model: typeof Record, options?: IHasAndBelongsToManyReflectionOptions);
+// export function hasMany(name: string, model: Record, options?: IHasAndBelongsToManyReflectionOptions);
 // export function hasMany(name: string, options: IHasAndBelongsToManyReflectionOptions);
-export function hasAndBelongsToMany(name, model, options) {
+export function hasAndBelongsToMany(name, model, scope, options) {
+    if (Record.isPrototypeOf(name)) {
+        options = scope;
+        scope = model;
+        model = name;
+        name = model.modelName().plural;
+    }
+    
+    if (typeof scope !== 'function') {
+        options = scope;
+        scope = null;
+    }
+    
     return {
         reflection: HasAndBelongsToManyReflection,
-        args: [name, model, options]
+        args: [name, model, scope, options]
     };
 }

--- a/lib/viking/record/reflections/hasManyReflection.js
+++ b/lib/viking/record/reflections/hasManyReflection.js
@@ -20,20 +20,12 @@ export default class HasManyReflection extends Reflection {
     // constructor(model: typeof Model, options?: IHasManyReflectionOptions);
     // constructor(name: string, model: Model, options?: IHasManyReflectionOptions);
     // constructor(name: string, options: IHasManyReflectionOptions);
-    constructor(name, model, options) {
-        if (Record.isPrototypeOf(name)) {
-            options = model;
-            model = name;
-            name = model.modelName().plural;
-        } else if (!Record.isPrototypeOf(model)) {
-            options = model;
-            model = undefined;
-        }
-
+    constructor(name, model, scope, options) {
         super();
         this.name = name;
         this.macro = 'hasMany';
         this.model = model;
+        this.scope = scope;
         this.options = options ? options : {};
     }
 
@@ -58,9 +50,21 @@ export default class HasManyReflection extends Reflection {
 // export function hasMany(model: typeof Model, options?: IHasManyReflectionOptions);
 // export function hasMany(name: string, model: Model, options?: IHasManyReflectionOptions);
 // export function hasMany(name: string, options: IHasManyReflectionOptions);
-export function hasMany(name, model, options) {
+export function hasMany(name, model, scope, options) {
+    if (Record.isPrototypeOf(name)) {
+        options = scope;
+        scope = model;
+        model = name;
+        name = model.modelName().plural;
+    }
+    
+    if (typeof scope !== 'function') {
+        options = scope;
+        scope = null;
+    }
+
     return {
         reflection: HasManyReflection,
-        args: [name, model, options]
+        args: [name, model, scope, options]
     };
 }

--- a/lib/viking/record/reflections/hasOneReflection.js
+++ b/lib/viking/record/reflections/hasOneReflection.js
@@ -11,22 +11,12 @@ export default class HasOneReflection extends Reflection {
     // constructor(model: typeof Model, options?: IBelongsToReflectionOptions);
     // constructor(name: string, model: Model, options?: IBelongsToReflectionOptions);
     // constructor(name: string, options: IBelongsToReflectionOptions);
-    constructor(name, model, options) {
+    constructor(name, model, scope, options) {
         super();
-        
-        if (Record.isPrototypeOf(name)) {
-            options = model;
-            model = name;
-            name = model.modelName().singular;
-        } else if (!Record.isPrototypeOf(model)) {
-            options = model;
-            model = undefined;
-        }
-
-
         this.name = name;
         this.macro = 'hasOne';
         this.model = model || (options ? options.model : undefined);
+        this.scope = scope;
         this.options = options || {};
     }
 
@@ -82,9 +72,21 @@ export default class HasOneReflection extends Reflection {
 // export function belongsTo(model: typeof Model, options?: IBelongsToReflectionOptions);
 // export function belongsTo(name: string, model: Model, options?: IBelongsToReflectionOptions);
 // export function belongsTo(name: string, options: IBelongsToReflectionOptions);
-export function hasOne(name, model, options) {
+export function hasOne(name, model, scope, options) {
+    if (Record.isPrototypeOf(name)) {
+        options = scope;
+        scope = model;
+        model = name;
+        name = model.modelName().singular;
+    }
+    
+    if (typeof scope !== 'function') {
+        options = scope;
+        scope = null;
+    }
+    
     return {
         reflection: HasOneReflection,
-        args: [name, model, options]
+        args: [name, model, scope, options]
     };
 }

--- a/test/record/associations/belongsToTest.js
+++ b/test/record/associations/belongsToTest.js
@@ -184,6 +184,22 @@ describe('Viking.Record::associations', () => {
         });
     });
 
+    describe('belongsTo(Parent, scope)', () => {
+        it("ordering", function() {
+            class Parent extends VikingRecord { }
+            class Model extends VikingRecord {
+                static associations = [belongsTo(Parent, (r) => r.order({created_at: 'asc'}))];
+            }
+
+            let model = new Model({parent_id: 25});
+
+            model._associations['parent'].load();
+            assert.ok(this.findRequest('GET', '/parents', {
+                params: {where: {id: 25}, order: {created_at: 'asc'}, limit: 1}
+            }));
+        });
+    });
+
     describe('belongsTo(Parent, {foriegnKey: KEY})', () => {
         class Parent extends VikingRecord { }
         class Model extends VikingRecord {

--- a/test/record/associations/hasAndBelongsToManyTest.js
+++ b/test/record/associations/hasAndBelongsToManyTest.js
@@ -26,6 +26,18 @@ describe('Viking.Record::associations', () => {
                 xhr.respond(200, {}, '[{"id": 2, "name": "Viking"}]');
             });
         });
+        
+        it("order", function() {
+            class Parent extends VikingRecord { }
+            class Model extends VikingRecord {
+                static associations = [hasAndBelongsToMany(Parent, {order: {created_at: 'asc'}})];
+            }
+            
+            let model = new Model({id: 24});
+
+            model.parents.toArray()
+            assert.ok(this.requests.find(req => req.url == "http://example.com/parents?where%5Bmodels_parents%5D%5Bmodel_id%5D=24&order%5Bcreated_at%5D=asc"))
+        });
 
         describe('assigning the association', () => {
 

--- a/test/record/associations/hasAndBelongsToManyTest.js
+++ b/test/record/associations/hasAndBelongsToManyTest.js
@@ -26,18 +26,6 @@ describe('Viking.Record::associations', () => {
                 xhr.respond(200, {}, '[{"id": 2, "name": "Viking"}]');
             });
         });
-        
-        it("order", function() {
-            class Parent extends VikingRecord { }
-            class Model extends VikingRecord {
-                static associations = [hasAndBelongsToMany(Parent, {order: {created_at: 'asc'}})];
-            }
-            
-            let model = new Model({id: 24});
-
-            model.parents.toArray()
-            assert.ok(this.requests.find(req => req.url == "http://example.com/parents?where%5Bmodels_parents%5D%5Bmodel_id%5D=24&order%5Bcreated_at%5D=asc"))
-        });
 
         describe('assigning the association', () => {
 
@@ -133,7 +121,23 @@ describe('Viking.Record::associations', () => {
             })
         })
     });
+    
+    describe('hasAndBelongsToMany(Parent, scope)', () => {
+        it("ordering", function() {
+            class Parent extends VikingRecord { }
+            class Model extends VikingRecord {
+                static associations = [hasAndBelongsToMany(Parent, (r) => r.order({created_at: 'asc'}))];
+            }
+        
+            let model = new Model({id: 24});
 
+            model.parents.load();
+            assert.ok(this.findRequest('GET', '/parents', {
+                params: {where: {models_parents: {model_id: 24}}, order: {created_at: 'asc'}}
+            }));
+        });
+    });
+    
     describe('hasAndBelongsToMany(Parent, {foriegnKey: KEY})', () => {
         class Parent extends VikingRecord { }
         class Model extends VikingRecord {

--- a/test/record/associations/hasManyTest.js
+++ b/test/record/associations/hasManyTest.js
@@ -26,6 +26,19 @@ describe('Viking.Record::associations', () => {
             });
         });
         
+        it("order", function() {
+            class Parent extends VikingRecord { }
+            class Model extends VikingRecord {
+                static associations = [hasMany(Parent, {order: {created_at: 'asc'}})];
+            }
+            
+            let model = new Model({id: 24});
+
+            model.parents.toArray()
+            
+            assert.ok(this.requests.find(req => req.url == "http://example.com/parents?where%5Bmodel_id%5D=24&order%5Bcreated_at%5D=asc"))
+        });
+        
         it("forEach iterates over the association", function(done) {
             let model = new Model({id: 24});
             let loaded_parents = [];

--- a/test/record/associations/hasManyTest.js
+++ b/test/record/associations/hasManyTest.js
@@ -25,20 +25,7 @@ describe('Viking.Record::associations', () => {
                 xhr.respond(200, {}, '[{"id": 2, "name": "Viking"}]');
             });
         });
-        
-        it("order", function() {
-            class Parent extends VikingRecord { }
-            class Model extends VikingRecord {
-                static associations = [hasMany(Parent, {order: {created_at: 'asc'}})];
-            }
-            
-            let model = new Model({id: 24});
 
-            model.parents.toArray()
-            
-            assert.ok(this.requests.find(req => req.url == "http://example.com/parents?where%5Bmodel_id%5D=24&order%5Bcreated_at%5D=asc"))
-        });
-        
         it("forEach iterates over the association", function(done) {
             let model = new Model({id: 24});
             let loaded_parents = [];
@@ -196,7 +183,24 @@ describe('Viking.Record::associations', () => {
         })
     });
     
-
+    describe('hasMany(Parent, scope)', () => {
+        it("ordering", function () {
+            class Parent extends VikingRecord { }
+            class Model extends VikingRecord {
+                static associations = [hasMany(Parent, (r) => r.order({created_at: 'asc'}))];
+            }
+    
+            let model = new Model({id: 24});
+            model.parents.load();
+            assert.ok(this.findRequest('GET', '/parents', {
+                params: {
+                    where: {model_id: 24},
+                    order: {created_at: 'asc'}
+                }
+            }));
+        });
+    });
+    
     // describe('belongsTo(Parent, {foriegnKey: KEY})', () => {
     //     class Parent extends VikingRecord { }
     //     class Model extends VikingRecord {

--- a/test/record/associations/hasOneTest.js
+++ b/test/record/associations/hasOneTest.js
@@ -139,6 +139,22 @@ describe('Viking.Record::associations', () => {
         })
     });
    
+    describe('hasOne(Parent, scope)', () => {
+        it("ordering", function() {
+            class Parent extends VikingRecord { }
+            class Model extends VikingRecord {
+                static associations = [hasOne(Parent, (r) => r.order({created_at: 'asc'}))];
+            }
+
+            let model = new Model({id: 25});
+
+            model._associations['parent'].load();
+            assert.ok(this.findRequest('GET', '/parents', {
+                params: {where: {model_id: 25}, order: {created_at: 'asc'}, limit: 1}
+            }));
+        });
+    });
+
     describe('hasOne(Parent, {foriegnKey: KEY})', () => {
         class Parent extends VikingRecord { }
         class Model extends VikingRecord {

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -55,7 +55,16 @@ before(function() {
         this.requests.push(xhr);
     };
 
-    this.withRequest = (method, url, {params = null, body =  null} = {}, callback) => {
+    this.withRequest = (method, url, options, callback) => {
+        let match = this.findRequest(method, url, options);
+
+        if (match) {
+            callback(match);
+            this.requests = this.requests.filter(xhr => xhr !== match);
+        }
+    };
+    
+    this.findRequest = (method, url, {params = null, body =  null} = {}) => {
         if (params && Object.keys(params).length > 0) { url += `?${toQuery(params)}`; }
 
         let match = this.requests.find((xhr) => {
@@ -72,15 +81,15 @@ before(function() {
             return ;
         });
 
-        if (match) {
-            callback(match);
-            this.requests = this.requests.filter(xhr => xhr !== match)
-        } else {
+        if (!match) {
             this.requests.forEach((xhr) => {
-                console.log("\x1b[33m", "\t! MISSED\t" + [xhr.method, decodeURIComponent(xhr.url), xhr.requestBody].filter(x => x).join("\t"));
+                console.error("\x1b[33m", "\t! MISSED\t" + [xhr.method, decodeURIComponent(xhr.url), xhr.requestBody].filter(x => x).join("\t"));
             });
         }
+        
+        return match;
     };
+
 });
 
 after(function () {


### PR DESCRIPTION
Support order in collection reflections

Example:
```javascript
class Model extends VikingRecord {
    static associations = [hasMany(Parent, {order: {created_at: 'asc'}})];
}
```