### PR TITLE
Allow record default to be a function

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -282,7 +282,7 @@ export default class Record extends EventBus {
         let dflts = {};
         each(this.constructor.schema, (key, options) => {
             if (options.default) {
-                dflts[key] = options.default;
+                dflts[key] = result(options, 'default');
             }
         });
 

--- a/test/record/defaultsTest.js
+++ b/test/record/defaultsTest.js
@@ -46,6 +46,21 @@ describe('Viking.Record', () => {
             let emptyattrs = new Defaulted();
             assert.equal(emptyattrs.attributes.one, 1);
         });
+        
+        it('is a function', function () {
+            class Pow extends Model {
+                static base = 3;
+                static schema = {
+                    square: {
+                        type: 'integer',
+                        default: () => this.base * this.base
+                    }
+                }
+            }
+            
+            const three = new Pow();
+            assert.equal(9, three.square);
+        });
 
     });
 });


### PR DESCRIPTION
```javascript
import ApplicationRecord from './application-record';
static schema = {
  size_units: {type: 'string', default: () => ApplicationRecord.defaultAreaUnits() }
}
```