### PR TITLE
add “as” option for collection associations

### DIFF
--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -176,8 +176,22 @@ export default class CollectionAssociation extends Association {
     foreignKey() {
         if (this.reflection.options.foreignKey) {
             return this.reflection.options.foreignKey;
-        } else if (this.owner.modelName) {
+        } else if (this.reflection.options.as) {
+            return this.reflection.options.as + '_id';
+        }else if (this.owner.modelName) {
             return this.owner.modelName.paramKey + '_id';
+        } else {
+            return 'x';
+        }
+    }
+    
+    foreignType () {
+        if (this.reflection.options.foreignType) {
+            return this.reflection.options.foreignType;
+        } else if (this.reflection.options.as) {
+            return this.reflection.options.as + '_type';
+        } else if (this.owner.modelName) {
+            return this.owner.modelName.paramKey + '_type';
         } else {
             return 'x';
         }

--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -178,7 +178,7 @@ export default class CollectionAssociation extends Association {
             return this.reflection.options.foreignKey;
         } else if (this.reflection.options.as) {
             return this.reflection.options.as + '_id';
-        }else if (this.owner.modelName) {
+        } else if (this.owner.modelName) {
             return this.owner.modelName.paramKey + '_id';
         } else {
             return 'x';

--- a/lib/viking/record/associations/hasManyAssociation.js
+++ b/lib/viking/record/associations/hasManyAssociation.js
@@ -9,6 +9,12 @@ export default class HasManyAssociation extends CollectionAssociation {
             [this.foreignKey()]: this.owner.readAttribute(this.primaryKey())
         })
         
+        if (this.reflection.options.as) {
+            relation = relation.where({
+                [this.foreignType()]: this.owner.modelName.name
+            })
+        }
+        
         if (this.reflection.scope) {
             relation = this.reflection.scope.call(this.owner, relation);
         }

--- a/test/record/associations/hasManyTest.js
+++ b/test/record/associations/hasManyTest.js
@@ -213,42 +213,79 @@ describe('Viking.Record::associations', () => {
         });
     });
     
-    // describe('belongsTo(Parent, {foriegnKey: KEY})', () => {
-    //     class Parent extends VikingRecord { }
-    //     class Model extends VikingRecord {
-    //         static associations = [belongsTo(Parent, {foreignKey: 'parental_id'})];
-    //     }
+    describe('hasMany(Parent, {foriegnKey: KEY})', () => {
+        class Parent extends VikingRecord { }
+        class Child extends VikingRecord {
+            static associations = [hasMany(Parent, {foreignKey: 'offspring_id'})];
+        }
 
-    //     it("load association", function(done) {
-        //         let model = new Model({parental_id: 24});
+        it("load association", function(done) {
+            let model = new Child({id: 24});
 
-    //         model.parent.then((model) => {
-    //             assert.ok(model instanceof Parent);
-    //             assert.equal(model.readAttribute('id'), 24);
-    //             assert.equal(model.readAttribute('name'), 'Viking');
-    //         }).then(done, done);
-    //         this.withRequest('GET', '/parents', {where: {id: 24}, order: {id: 'desc'}, limit: 1}, (xhr) => {
-    //             xhr.respond(200, {}, '[{"id": 24, "name": "Viking"}]');
-    //         });
-    //     });
+            model.parents.toArray().then((models) => {
+                assert.ok(models[0] instanceof Parent);
+                assert.equal(models[0].readAttribute('id'), 11);
+                assert.equal(models[0].readAttribute('name'), 'Viking');
+            }).then(done, done);
+            this.withRequest('GET', '/parents', {params: {where: {offspring_id: 24}, order: {id: 'desc'}}}, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 11, "name": "Viking"}]');
+            });
 
-    //     describe('assigning the association', () => {
-    //         it('to a model with an id', function(done) {
-        //             let model = new Model();
-    //             let parent = new Parent({id: 13});
-    //             model.parent = parent;
+        });
 
-    //             assert.equal(model.readAttribute('parental_id'), 13);
-    //             assert.ok(model._associations.parent.loaded);
-    //             assert.strictEqual(model._associations.parent.target, parent);
-    //             model.parent.then((model) => {
-    //                 assert.strictEqual(model, parent);
-    //                 done();
-    //             });
-    //             assert.equal(this.requests.length, 0);
-    //         });
-    //     });
-    // });
+        describe('assigning the association', (done) => {
+            it('to a model with an id', function(done) {
+                let model = new Child({id: 24});
+                let parent = new Parent({id: 13});
+                model.parents = [parent];
+
+                assert.equal(parent.readAttribute('offspring_id'), 24);
+                assert.ok(model._associations.parents.loaded);
+                assert.strictEqual(model._associations.parents.target[0], parent);
+                model.parents.toArray().then(models => {
+                    assert.strictEqual(models[0], parent);
+                }).then(done, done);
+                assert.equal(this.requests.length, 0);
+            });
+        });
+    });
+    
+    describe('hasMany(Parent, {as: NAME})', () => {
+        class Parent extends VikingRecord { }
+        class Child extends VikingRecord {
+            static associations = [hasMany(Parent, {as: 'offspring'})];
+        }
+
+        it("load association", function(done) {
+            let model = new Child({id: 24});
+
+            model.parents.toArray().then((models) => {
+                assert.ok(models[0] instanceof Parent);
+                assert.equal(models[0].readAttribute('id'), 11);
+                assert.equal(models[0].readAttribute('name'), 'Viking');
+            }).then(done, done);
+            this.withRequest('GET', '/parents', {params: {where: {offspring_id: 24}, order: {id: 'desc'}}}, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 11, "name": "Viking"}]');
+            });
+
+        });
+
+        describe('assigning the association', (done) => {
+            it('to a model with an id', function(done) {
+                let model = new Child({id: 24});
+                let parent = new Parent({id: 13});
+                model.parents = [parent];
+
+                assert.equal(parent.readAttribute('offspring_id'), 24);
+                assert.ok(model._associations.parents.loaded);
+                assert.strictEqual(model._associations.parents.target[0], parent);
+                model.parents.toArray().then(models => {
+                    assert.strictEqual(models[0], parent);
+                }).then(done, done);
+                assert.equal(this.requests.length, 0);
+            });
+        });
+    });
 
     // // Model.reflectOnAssociation('parent');
 

--- a/test/record/associations/hasManyTest.js
+++ b/test/record/associations/hasManyTest.js
@@ -264,7 +264,7 @@ describe('Viking.Record::associations', () => {
                 assert.equal(models[0].readAttribute('id'), 11);
                 assert.equal(models[0].readAttribute('name'), 'Viking');
             }).then(done, done);
-            this.withRequest('GET', '/parents', {params: {where: {offspring_id: 24}, order: {id: 'desc'}}}, (xhr) => {
+            this.withRequest('GET', '/parents', {params: {where: {offspring_id: 24, offspring_type: 'Child'}, order: {id: 'desc'}}}, (xhr) => {
                 xhr.respond(200, {}, '[{"id": 11, "name": "Viking"}]');
             });
 

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -108,7 +108,7 @@ before(function() {
         if (!match) {
             this.requests.forEach((xhr) => {
                 console.error("\x1b[33m", "!!! MISSED REQUEST !!!!!")
-                console.error("\x1b[33m", "\tREQUESTS\n\t\t" + [method, decodeURIComponent('http://example.com' + url), JSON.stringify(options?.body)].filter(x => x).join("\t"));
+                console.error("\x1b[33m", "\tREQUEST\n\t\t" + [method, decodeURIComponent('http://example.com' + url), JSON.stringify(options?.body)].filter(x => x).join("\t"));
                 console.error("\x1b[33m", "\tQUEUE\n\t\t" + [xhr.method, decodeURIComponent(xhr.url), xhr.requestBody].filter(x => x).join("\t"));
                 console.error("\x1b[33m", "!!!!!!!!!!!!!!!!!!!!!!!!");
             });


### PR DESCRIPTION
```javascript
class Parent extends VikingRecord { }
class Child extends VikingRecord {
  static associations = [hasMany(Parent, {as: 'offspring'})];
}
```