### PR TITLE
Add callbacks to record

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -72,6 +72,13 @@ export default class Record extends EventBus {
 
     static path;//: undefined | string;
     
+    static beforeSave = [];
+    static beforeCreate = [];
+    static beforeDestroy = [];
+    static afterSave = [];
+    static afterCreate = [];
+    static afterDestroy = [];
+    
     static initializeAssociations() {
         if (!this.hasOwnProperty('_associations')) {
             this._associations = {};
@@ -533,6 +540,12 @@ export default class Record extends EventBus {
         if (!this.constructor.connection) {
             throw new Errors.ConnectionNotEstablished();
         }
+        
+        const wasNew = this.isNewRecord()
+        if (this.isNewRecord()) {
+            this.constructor.beforeCreate.forEach(x => result(this, x))
+        }
+        this.constructor.beforeSave.forEach(x => result(this, x))
 
         let method = this.isNewRecord() ? 'post' : 'put';
         let path   = this.isNewRecord() ? result(this, 'urlRoot') : this.url();
@@ -568,6 +581,11 @@ export default class Record extends EventBus {
             each(savedChanges, (key, value) => {
                 this.dispatchEvent('saved:'+key, value[0], value[1]);
             });
+            
+            if (wasNew) {
+                this.constructor.afterCreate.forEach(x => result(this, x))
+            }
+            this.constructor.afterSave.forEach(x => result(this, x))
             return true;
         }
         options.error = (request, error_callback) => {
@@ -613,9 +631,11 @@ export default class Record extends EventBus {
             // ... raise error
         }
         
+        this.constructor.beforeDestroy.forEach(x => result(this, x))
         this.dispatchEvent('ondestroy', this, options)
         await this.constructor.connection.delete(this.url()).then(() => {
             this.dispatchEvent('destroyed', this, options)
+            this.constructor.afterDestroy.forEach(x => result(this, x))
         });
         this._destroyed = true;
     }

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -1,6 +1,6 @@
 import * as Errors from './errors';
 import EventBus from './eventBus';
-import {each, result, uniqueId, isEqual, deepAssign} from './support';
+import {each, result, uniqueId, isEqual, deepAssign, isFunction} from './support';
 import { Name } from './record/name';
 // import { Reflection } from './model/reflection';
 // import { BelongsToReflection } from './model/reflections/belongs_to_reflection';
@@ -45,9 +45,11 @@ import { Reflection } from './record/reflection';
 //  |onremove|association|record is about to be removed from an association
 //  |removed|association|record has been removed from an association
 //  |invalid|errors|record has failed to save because it is invalid
+//  | oncreate                 | record, changes | record has successfully created |
 //  | onsave                 | record, changes | record has successfully saved |
 //  | saved                 | record, changes | record has successfully saved |
 //  | saved:[attribute]     | record, oldValue, newValue |
+//  | created                 | record, changes | record has successfully created |
 //  | changed                | record, changes |
 //  | changed:[attribute]    | record, oldValue, newValue |
 //  |ondestroy||record is about to request to destroy
@@ -276,6 +278,24 @@ export default class Record extends EventBus {
         this.setAttributes(this.defaults());
         
         this.setAttributesAndAssociations(attributes);
+        
+        const callbacks = {
+            'beforeSave': 'onsave',
+            'beforeCreate': 'oncreate',
+            'beforeDestroy': 'ondestroy',
+            'afterSave': 'saved',
+            'afterCreate': 'created',
+            'afterDestroy': 'destroyed'
+        }
+        Object.keys(callbacks).forEach(callbackName => {
+            const event = callbacks[callbackName]
+            this.constructor[callbackName].forEach(callback => {
+                if (!isFunction(callback)) {
+                    callback = this[callback]
+                }
+                this.addEventListener(event, callback)
+            })
+        })
     }
 
     // Alias for `::urlRoot`
@@ -540,13 +560,12 @@ export default class Record extends EventBus {
         if (!this.constructor.connection) {
             throw new Errors.ConnectionNotEstablished();
         }
-        
-        const wasNew = this.isNewRecord()
         if (this.isNewRecord()) {
-            this.constructor.beforeCreate.forEach(x => result(this, x))
+            this.dispatchEvent('oncreate', this.changedAttributes(), options)
         }
-        this.constructor.beforeSave.forEach(x => result(this, x))
-
+        this.dispatchEvent('onsave', this.changedAttributes(), options)
+        
+        const wasNew = this.isNewRecord();
         let method = this.isNewRecord() ? 'post' : 'put';
         let path   = this.isNewRecord() ? result(this, 'urlRoot') : this.url();
         
@@ -577,15 +596,13 @@ export default class Record extends EventBus {
             let savedChanges = {};
             deepAssign(savedChanges, this._changes);
             this.persist();
+            if(wasNew) {
+                this.dispatchEvent('created', savedChanges, options);
+            }
             this.dispatchEvent('saved', savedChanges, options);
             each(savedChanges, (key, value) => {
                 this.dispatchEvent('saved:'+key, value[0], value[1]);
             });
-            
-            if (wasNew) {
-                this.constructor.afterCreate.forEach(x => result(this, x))
-            }
-            this.constructor.afterSave.forEach(x => result(this, x))
             return true;
         }
         options.error = (request, error_callback) => {
@@ -595,8 +612,6 @@ export default class Record extends EventBus {
                 return false;
             }
         }
-
-        this.dispatchEvent('onsave', this.changedAttributes(), options)
         return await this.constructor.connection[method](path, options);
 
         // options.error = function (resp) {
@@ -631,11 +646,9 @@ export default class Record extends EventBus {
             // ... raise error
         }
         
-        this.constructor.beforeDestroy.forEach(x => result(this, x))
         this.dispatchEvent('ondestroy', this, options)
         await this.constructor.connection.delete(this.url()).then(() => {
             this.dispatchEvent('destroyed', this, options)
-            this.constructor.afterDestroy.forEach(x => result(this, x))
         });
         this._destroyed = true;
     }

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -560,12 +560,12 @@ export default class Record extends EventBus {
         if (!this.constructor.connection) {
             throw new Errors.ConnectionNotEstablished();
         }
-        if (this.isNewRecord()) {
+        const wasNew = this.isNewRecord();
+        
+        if (wasNew) {
             this.dispatchEvent('oncreate', this.changedAttributes(), options)
         }
         this.dispatchEvent('onsave', this.changedAttributes(), options)
-        
-        const wasNew = this.isNewRecord();
         let method = this.isNewRecord() ? 'post' : 'put';
         let path   = this.isNewRecord() ? result(this, 'urlRoot') : this.url();
         

--- a/lib/viking/support.js
+++ b/lib/viking/support.js
@@ -101,7 +101,7 @@ export function each(value, callback) {
     }
 }
 
-function isFunction(object) {
+export function isFunction(object) {
     return !!(object && object.constructor && object.call && object.apply);
 }
 

--- a/test/record/callbacksTest.js
+++ b/test/record/callbacksTest.js
@@ -1,0 +1,182 @@
+import 'mocha';
+import * as assert from 'assert';
+import Record from 'viking/record';
+
+describe('Viking.Record#callbacks', () => {
+    
+    describe('create', () => {
+        class Actor extends Record {
+            static schema = {
+                score: {type: 'integer'}
+            }
+            
+            static beforeCreate = [
+                'startScore'
+            ]
+            
+            static afterCreate = [
+                'endScore'
+            ]
+            
+            startScore () {
+                this.score = 1
+            }
+            
+            endScore () {
+                this.score = 99
+            }
+        }
+        it('before', function () {
+            const model = new Actor();
+            assert.equal(model.score, null)
+            model.save()
+            assert.ok(this.findRequest('POST', '/actors', {
+                body: {
+                    actor: {
+                        score: 1
+                    }
+                }
+            }));
+        })
+        
+        it('not on save', function(done) {
+            Actor.find(1).then(model => {
+                model.score = 11
+                model.save().then(() => {
+                    assert.equal(model.score, 11)
+                }).then(done, done)
+
+                this.withRequest('PUT', '/actors/1', { body: {actor: {score: 11} } }, (xhr) => {
+                    xhr.respond(201, {}, '{"id": 1, "score": 11}');
+                });
+            });
+            this.withRequest('GET', '/actors', { params: {where: {id: 1}, order:{id: 'desc'}, limit: 1} }, (xhr) => {
+                xhr.respond(201, {}, '[{"id": 1, "score": 1}]');
+            });
+        })
+
+        it('after', function (done) {
+            const model = new Actor();
+            assert.equal(model.score, null)
+            model.save().then(() => {
+                assert.equal(model.score, 99)
+            }).then(done, done)
+
+            this.withRequest('POST', '/actors', { body: {actor: {score: 1} } }, (xhr) => {
+                xhr.respond(201, {}, '{"id": 1, "score": 1}');
+            });
+        })
+    })
+    
+    describe('save', async () => {
+        class Actor extends Record {
+            static schema = {
+                score: {type: 'integer'}
+            }
+            
+            static beforeSave = [
+                'startScore'
+            ]
+            
+            static afterSave = [
+                'endScore'
+            ]
+            
+            startScore () {
+                this.score = 2
+            }
+            
+            endScore () {
+                this.score = 99
+            }
+        }
+        
+        it('before', function (done) {
+            Actor.find(1).then(model => {
+                model.score = 11
+                assert.equal(model.score, 11)
+                model.save()
+                assert.ok(this.findRequest('PUT', '/actors/1', {
+                    body: {
+                        actor: {
+                            score: 2
+                        }
+                    }
+                }));
+            }).then(done, done)
+            this.withRequest('GET', '/actors', { params: {where: {id: 1}, order:{id: 'desc'}, limit: 1} }, (xhr) => {
+                xhr.respond(201, {}, '[{"id": 1, "score": 1}]');
+            });
+        })
+
+        it('after', function (done) {
+            Actor.find(1).then(model => {
+                model.score = 11
+                assert.equal(model.score, 11)
+                model.save().then(() => {
+                    assert.equal(model.score, 99)
+                }).then(done, done)
+            
+                this.withRequest('PUT', '/actors/1', { body: {actor: {score: 2} } }, (xhr) => {
+                    xhr.respond(201, {}, '{"id": 1, "score": 2}');
+                });
+            })
+            this.withRequest('GET', '/actors', { params: {where: {id: 1}, order:{id: 'desc'}, limit: 1} }, (xhr) => {
+                xhr.respond(201, {}, '[{"id": 1, "score": 1}]');
+            });
+        })
+    })
+    
+    describe('destroy', async () => {
+        let beforeDestroyFlag = false;
+        let afterDestroyFlag = false;
+        
+        class Actor extends Record {
+            static schema = {
+                score: {type: 'integer'}
+            }
+            
+            static beforeDestroy = [
+                'beforeDestroyFlag'
+            ]
+            
+            static afterDestroy = [
+                'afterDestroyFlag'
+            ]
+            
+            beforeDestroyFlag () {
+                beforeDestroyFlag = true
+            }
+            
+            afterDestroyFlag () {
+                afterDestroyFlag = true
+            }
+        }
+        
+        it('before', function (done) {
+            Actor.find(1).then(model => {
+                model.destroy()
+                assert.ok(beforeDestroyFlag)
+            }).then(done, done)
+            this.withRequest('GET', '/actors', { params: {where: {id: 1}, order:{id: 'desc'}, limit: 1} }, (xhr) => {
+                xhr.respond(201, {}, '[{"id": 1, "score": 1}]');
+            });
+        })
+
+        it('after', function (done) {
+            Actor.find(1).then(model => {
+                model.destroy().then(() => {
+                    assert.ok(afterDestroyFlag)
+                }).then(done, done)
+            
+                this.withRequest('DELETE', '/actors/1', {}, (xhr) => {
+                    xhr.respond(201, {}, '{"id": 1, "score": 2}');
+                });
+            })
+            this.withRequest('GET', '/actors', { params: {where: {id: 1}, order:{id: 'desc'}, limit: 1} }, (xhr) => {
+                xhr.respond(201, {}, '[{"id": 1, "score": 1}]');
+            });
+        })
+    })
+
+});

--- a/test/record/eventsTest.js
+++ b/test/record/eventsTest.js
@@ -2,7 +2,7 @@ import 'mocha';
 import * as assert from 'assert';
 import Record from 'viking/record';
 
-describe('Viking.Record#callbacks', () => {
+describe('Viking.Record#events', () => {
 
     class Actor extends Record {
         static schema = {


### PR DESCRIPTION
Support callbacks on record:
- beforeCreate
- beforeSave
- beforeDestroy
- afterCreate
- afterSave
- afterDestroy

```javascript
class Actor extends Record {
    static schema = {
        score: {type: 'integer'}
    }
    
    static beforeCreate = [
        'startScore'
    ]
    
    startScore () {
        this.score = 1
    }
}
```