### PR TITLE
fix collection association adding record when it should not

### DIFF
--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -162,7 +162,9 @@ export default class CollectionAssociation extends Association {
     }
 
     push (record) {
-        this.setTarget(this.target.concat([record]))
+        if (!this.target.find(x => x.cid == record.cid)){
+            this.setTarget(this.target.concat([record]))
+        }
     }
     
     add (record, options) {

--- a/test/record/associations/events/belongsToEventTest.js
+++ b/test/record/associations/events/belongsToEventTest.js
@@ -29,7 +29,7 @@ describe('Viking.Record::ssociations', () => {
             
             model.parent = parent
         
-            parent.addEventListener('added', association => {
+            parent.addEventListener('afterAdd', association => {
                 assert.ok(false)
             })
             

--- a/test/record/associations/events/hasManyEventTest.js
+++ b/test/record/associations/events/hasManyEventTest.js
@@ -48,6 +48,20 @@ describe('Viking.Record::ssociations', () => {
             model.parents.push(parent)
         })
         
+        it("adding target that's already in target does not fire add event", function (done){
+            let model = new Model();
+            let parent = new Parent({id: 24});
+            
+            model.parents = [parent]
+        
+            parent.addEventListener('afterAdd', association => {
+                assert.ok(false)
+            })
+            
+            model.parents.push(parent)
+            done()
+        })
+
         it("setting target fires add event on record", function (done){
             let model = new Model({id: 11});
             let parent = new Parent({id: 24});


### PR DESCRIPTION
```javascript
            let model = new Model();
            let parent = new Parent({id: 24});
            
            model.parents = [parent]
        
            parent.addEventListener('afterAdd', association => {
                assert.ok(false)
            })
            
            model.parents.push(parent)
            done()
```