### PR TITLE
add support for records schema to have a function for type

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -394,14 +394,18 @@ export default class Record extends EventBus {
             let coercedValue = undefined;
 
             if (schema && schema[key] && schema[key].type) {
-                if (schema[key].array) {
-                    if (value === null || value === undefined) {
-                        coercedValue = null;
+                if (isFunction(schema[key].type) || Types.registry[schema[key].type]) {
+                    const coercionFunction = isFunction(schema[key].type) ? schema[key].type : Types.registry[schema[key].type].load
+                    
+                    if (schema[key].array) {
+                        if (value === null || value === undefined) {
+                            coercedValue = null;
+                        } else {
+                            coercedValue = value.map((v) => coercionFunction(v, attributes));
+                        }
                     } else {
-                        coercedValue = value.map((v) => Types.registry[schema[key].type].load(v));
+                        coercedValue = coercionFunction(value, attributes);
                     }
-                } else if (Types.registry[schema[key].type]) {
-                    coercedValue = Types.registry[schema[key].type].load(value);
                 } else {
                     throw new TypeError("Coercion of " + schema[key].type + " unsupported");
                 }
@@ -409,7 +413,6 @@ export default class Record extends EventBus {
                 coercedValue = value;
                 // throw new TypeError("Coercion of " + options.type + " unsupported");
             }
-
             callback(key, coercedValue);
         });
     }
@@ -479,6 +482,7 @@ export default class Record extends EventBus {
     }
     
     setAttributesAndAssociations(attributes, dirty=true) {
+        const recordAttributes = {}
         each(attributes, (key, value) => {
             if (this._associations.hasOwnProperty(key)) {
                 const association = this.association(key);
@@ -488,9 +492,10 @@ export default class Record extends EventBus {
                     association.setAttributes(value, dirty);
                 }
             } else {
-                this.setAttribute(key, value);
+                recordAttributes[key] = value;
             }
         });
+        this.setAttributes(recordAttributes);
     }
 
     primaryKey() {

--- a/test/record/types/dynamicTypeTest.js
+++ b/test/record/types/dynamicTypeTest.js
@@ -1,0 +1,34 @@
+import 'mocha';
+import * as assert from 'assert';
+import VikingRecord from 'viking/record';
+import Types from 'viking/record/types';
+
+describe('Viking.Record.Types', () => {
+    describe('Dynamic', () => {
+        
+        class Trait extends VikingRecord {
+            static schema = {
+                value_type: {type: "string"},
+                value: {
+                    type: (value, attrs) => {
+                        return Types.registry[attrs.value_type].load(value)
+                    }
+                }
+            }
+        }
+
+        it("type: function()", function() {
+            let trait = new Trait({ value_type: 'boolean', value: 'true' })
+            assert.equal(trait.value, true);
+            
+            trait = new Trait({ value_type: 'string', value: 'true' })
+            assert.equal(trait.value, 'true');
+            
+            trait = new Trait({ value_type: 'integer', value: '123' })
+            assert.equal(trait.value, 123);
+            
+            trait = new Trait({ value_type: 'date', value: "2013-04-10" })
+            assert.equal(trait.value.valueOf(), new Date(1365570000000).valueOf());
+        });
+    });
+});


### PR DESCRIPTION
Add support for record to have a dynamic type for an attribute

```javascript
class Trait extends VikingRecord {
    static schema = {
        value_type: {type: "string"},
        value: {
            type: (value, attrs) => {
                return Types.registry[attrs.value_type].load(value)
            }
        }
    }
}
```