### PR TITLE
add test and fix

### DIFF
--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -71,6 +71,7 @@ export default class Relation extends EventBus {
         spawned._where = clone(this._where);
         spawned._order = clone(this._order);
         spawned._include = clone(this._include);
+        spawned._distinct = clone(this._distinct);
         return spawned;
     }
 

--- a/lib/viking/support.js
+++ b/lib/viking/support.js
@@ -135,7 +135,7 @@ export function domReady(callback) {
 }
 
 export function clone(value) {
-    if (value === undefined) return value;
+    if (value === undefined || value === null) return value;
     if (Array.isArray(value)) {
         let dup = [];
         
@@ -144,7 +144,7 @@ export function clone(value) {
         });
         
         return dup;
-    } else if (value.__proto__ == Object.prototype) {
+    } else if (typeof value == "object" && value.__proto__ == Object.prototype) {
         let dup = {};
         Object.keys(value).forEach((k) => {
             dup[k] = clone(value[k]);

--- a/test/record/relationTest.js
+++ b/test/record/relationTest.js
@@ -176,6 +176,29 @@ describe('Viking.Relation', () => {
         })
     })
     
+    describe('distinct', () => {
+        it('no key', function () {
+            let relation = Model.where({parent_id: 11}).distinct()
+            
+            relation.load()
+            assert.ok(this.findRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'}, distinct: true } }));
+        })
+        
+        it('single key', function () {
+            let relation = Model.where({parent_id: 11}).distinct('session_id')
+            
+            relation.load()
+            assert.ok(this.findRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'}, distinct_on: ['session_id'] } }));
+        })
+        
+        it('dinstinct then spawn', function () {
+            let relation = Model.where({parent_id: 11}).distinct().order('created_at')
+            
+            relation.load()
+            assert.ok(this.findRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {created_at: 'desc'}, distinct: true } }));
+        })
+    })
+    
     describe('add', () => {
         it('single record', async function () {
             let relation = Model.where({parent_id: 11})

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -110,7 +110,7 @@ before(function() {
         if (!match) {
             console.error("\x1b[33m", "!!! MISSED REQUESTS !!!!!")
             console.error("\x1b[33m", "\tREQUEST")
-            console.error("\x1b[33m", "\t\t" + [method, decodeURIComponent('http://example.com' + url + toQuery(options?.params)), JSON.stringify(options?.body)].filter(x => x).join("\t"));
+            console.error("\x1b[33m", "\t\t" + [method, decodeURIComponent('http://example.com' + url + `?${toQuery(options?.params)}`), JSON.stringify(options?.body)].filter(x => x).join("\t"));
             console.error("\x1b[33m", "\tQUEUE");
             this.requests.forEach((xhr) => {
                 console.error("\x1b[33m", "\t\t" + [xhr.method, decodeURIComponent(xhr.url), xhr.requestBody].filter(x => x).join("\t"));


### PR DESCRIPTION
Calling .distinct and then `spawn` resulted in spawn not including `distinct` The follow would not call count with distinct:

```javascript
Model.where({parent_id: 11}).distinct().count()
```

Fixes #100 