### PR TITLE
Allow relation.count to accept an attribute to count on

### DIFF
--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -241,8 +241,8 @@ export default class Relation extends EventBus {
         return result.length === 0 ? null : result[0];
     }
 
-    async count() {
-        let result = await this.spawn().setCalculate({count: '*'}).load();
+    async count(column) {
+        let result = await this.spawn().setCalculate({count: column || '*'}).load();
         return result.length === 0 ? null : result[0];
     }
 

--- a/test/record/classProperties/calculateTest.js
+++ b/test/record/classProperties/calculateTest.js
@@ -10,19 +10,32 @@ describe('Viking.Record', () => {
     class Ship extends VikingRecord { }
 
     it('::count', function(done) {
-        Ship.count((count) => {
+        Ship.count().then((count) => {
             assert.equal(count, 100);
-        }).then(() => done(), done);
+            done()
+        }, done);
 
         this.withRequest('GET', '/ships/calculate', { params: {order: {id: 'desc'}, select: {count: '*'} } }, (xhr) => {
             xhr.respond(200, {}, '[100]');
         });
     });
+    
+    it('::count attribute', function(done) {
+        Ship.count('model_id').then((count) => {
+            assert.equal(count, 5);
+            done()
+        }, done);
+
+        this.withRequest('GET', '/ships/calculate', { params: {order: {id: 'desc'}, select: {count: 'model_id'} } }, (xhr) => {
+            xhr.respond(200, {}, '[5]');
+        });
+    });
 
     it('::sum', function(done) {
-        Ship.sum('size', (count) => {
+        Ship.sum('size').then((count) => {
             assert.equal(count, 100);
-        }).then(() => done(), done);
+            done()
+        }, done);
 
         this.withRequest('GET', '/ships/calculate', { params: {order: {id: 'desc'}, select: {sum: 'size'} } }, (xhr) => {
             xhr.respond(200, {}, '[100]');


### PR DESCRIPTION
Allow this:
```javascript
View.count('session_id')
```