### PR TITLE
depends_on option for type registry

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -239,7 +239,6 @@ export default class Record extends EventBus {
     _destroyed  = false;
     _changes = {};// : any
     _associations = {};//: { [propName: string]: any; }
-    _unsettled_coercions = []
     errors = {};
     
     // Add a helper reference to get the model name from an model instance.
@@ -390,71 +389,30 @@ export default class Record extends EventBus {
             Object.values(this._associations).some(a => a.needsSaved());
     }
     
-    coerceAttributes(attributes, callback) {
+    coerceAttributes(changes, callback) {
         const schema = this.constructor.schema;
-
-        each(attributes, (key, value) => {
-            let coercedValue = undefined;
-
+        const queue = []
+        
+        const coerceAttribute = (key, value) => {
             if (schema && schema[key] && schema[key].type) {
-                
-                if (schema[key].array) {
-                    if (value === null || value === undefined) {
-                        coercedValue = null;
-                    } else {
-                        coercedValue = value.map((v) => this.coerceAttribute(key, v, attributes));
-                        if (coercedValue.find(x => x == "__unsettled__")) {
-                            return
-                        }
-                    }
-                } else if (Types.registry[schema[key].type]) {
-                    coercedValue = this.coerceAttribute(key, value, attributes);
-                    if (coercedValue == "__unsettled__") {
-                        return
+                const Type = Types.registry[schema[key].type]
+                if (Type) {
+                    const result = Type.load(value, key, changes, this, schema[key])
+                    if (result === false) {
+                        queue.push([key, value])
                     }
                 } else {
                     throw new TypeError("Coercion of " + schema[key].type + " unsupported");
                 }
-            } else {
-                coercedValue = value;
-            }
-
-            callback(key, coercedValue);
-        });
-    }
-    
-    coerceAttribute (attribute, value, attributes) {
-        const schema = this.constructor.schema;
-        const Type = Types.registry[schema[attribute].type]
-        if (Type.depends_on) {
-            let depends_on = Type.depends_on
-            
-            if (isFunction(depends_on)) depends_on = depends_on(schema[attribute])
-            if (!Array.isArray(depends_on)) depends_on = [depends_on]
-            let dependent_values = depends_on.map(v => attributes[v] || this.readAttribute(v))
-            if (dependent_values.filter(x => x !== undefined).length != dependent_values.length) {
-                const unsettled_coercion = this._unsettled_coercions.find(x => x[0] == attribute) || [
-                    attribute, value, 0
-                ]
-                // 1 below is number of attempts, should we allow more than one attempt?
-                if (unsettled_coercion[2] > 1) { 
-                    throw new TypeError("Coercion of " + attribute + " failed because unfound dependency")
-                } else {
-                    unsettled_coercion[2] += 1
-                    this._unsettled_coercions.push(unsettled_coercion)
-                    return "__unsettled__"
-                }
-            } else {
-                this._unsettled_coercions = this._unsettled_coercions.filter(x => x[0] != attribute)
-                depends_on.forEach((attribute, index) => {
-                    attributes[attribute] = dependent_values[index]
-                })
             }
         }
+        each(changes, coerceAttribute);
+        each(queue, coerceAttribute);
         
-        return Type.load(value, attribute, schema[attribute], attributes)
+        return changes
     }
     
+    // TODO `setAttribute` is not part of framework, exists as helper, remove? -BE
     setAttribute(attribute, value) {
         return this.setAttributes({
             [attribute]: value
@@ -475,7 +433,8 @@ export default class Record extends EventBus {
         // let current = this.attributes;
         // let changed = this.changed;
         // let prev = this._previousAttributes;
-        this.coerceAttributes(attributes, (key, value) => {
+        const foo = this.coerceAttributes(attributes)
+        each(foo, (key, value) => {
             if (!(key in this.attributes) || !isEqual(this.attributes[key], value)) {
                 changes[key] = [this.attributes[key], value];
                 
@@ -489,20 +448,17 @@ export default class Record extends EventBus {
                     this._changes[key] = [ this.attributes[key] || null, value ];
                 }
                 this.attributes[key] = value;
+                
+                this.dispatchEvent('changed:' + key, this, ...changes[key]);
             }
-        });
-
+        })
         // TODO: if id not defined in schema add?
         // if (this.constructor.primaryKey in attributes) {
         //     this.id = this.readAttribute(this.constructor.primaryKey);
         // }
 
         // Trigger all relevant attribute changes.
-        each(changes, (key, values) => {
-            this.dispatchEvent('changed:' + key, this, ...values);
-        });
-
-
+        
         // You might be wondering why there's a `while` loop here. Changes can
         // be recursively nested within `"change"` events.
         // if (changing) { return this; }
@@ -528,17 +484,13 @@ export default class Record extends EventBus {
                 } else {
                     association.setAttributes(value, dirty);
                 }
-            } else {
-                this.setAttribute(key, value);
+                delete attributes[key]
             }
         });
         
-        while (this._unsettled_coercions.length > 0) {
-            this._unsettled_coercions.forEach(coercion => {
-                this.setAttribute(...coercion)
-            })
-        }
+        this.setAttributes(attributes);
     }
+
 
     primaryKey() {
         return this.readAttribute(this.constructor.primaryKey);
@@ -571,23 +523,12 @@ export default class Record extends EventBus {
     dumpAttributes(attributes) {
         const dump = {};
         const schema = this.constructor.schema;
-        const queuedDumps = []
         
-        const dumpAttribute = (key, value) => {
+        each(attributes, (key, value) => {
             if (schema && schema[key] && schema[key].type) {
                 const Type = Types.registry[schema[key].type]
                 if (!Type) {
                     throw new TypeError("Coercion of " + schema[key].type + " unsupported");
-                }
-                if (Type.depends_on) {
-                    let depends_on = Type.depends_on
-                    if (isFunction(depends_on)) depends_on = depends_on(schema[key])
-                    if (!Array.isArray(depends_on)) depends_on = [depends_on]
-                    
-                    if (depends_on.length != depends_on.filter(x => Object.keys(dump).includes(x)).length) {
-                        queuedDumps.push([key, value])
-                        return
-                    }
                 }
                 if (schema[key].array) {
                     if (value === null || value === undefined) {
@@ -601,15 +542,12 @@ export default class Record extends EventBus {
             } else {
                 dump[key] = value;
             }
-        }
-        
-        each(attributes, dumpAttribute);
-        queuedDumps.forEach(attrs => dumpAttribute(...attrs))
+        });
         
         return dump;
     }
 
-    asJSON(attrs) {
+    asJSON() {
         return this.dumpAttributes(this.attributes);
     }
     

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -239,6 +239,7 @@ export default class Record extends EventBus {
     _destroyed  = false;
     _changes = {};// : any
     _associations = {};//: { [propName: string]: any; }
+    _unsettled_coercions = []
     errors = {};
     
     // Add a helper reference to get the model name from an model instance.
@@ -390,30 +391,68 @@ export default class Record extends EventBus {
     }
     
     coerceAttributes(attributes, callback) {
-        let schema = this.constructor.schema;
-        
+        const schema = this.constructor.schema;
+
         each(attributes, (key, value) => {
             let coercedValue = undefined;
 
             if (schema && schema[key] && schema[key].type) {
+                
                 if (schema[key].array) {
                     if (value === null || value === undefined) {
                         coercedValue = null;
                     } else {
-                        coercedValue = value.map((v) => Types.registry[schema[key].type].load(v));
+                        coercedValue = value.map((v) => this.coerceAttribute(key, v, attributes));
+                        if (coercedValue.find(x => x == "__unsettled__")) {
+                            return
+                        }
                     }
                 } else if (Types.registry[schema[key].type]) {
-                    coercedValue = Types.registry[schema[key].type].load(value);
+                    coercedValue = this.coerceAttribute(key, value, attributes);
+                    if (coercedValue == "__unsettled__") {
+                        return
+                    }
                 } else {
                     throw new TypeError("Coercion of " + schema[key].type + " unsupported");
                 }
             } else {
                 coercedValue = value;
-                // throw new TypeError("Coercion of " + options.type + " unsupported");
             }
 
             callback(key, coercedValue);
         });
+    }
+    
+    coerceAttribute (attribute, value, attributes) {
+        const schema = this.constructor.schema;
+        const Type = Types.registry[schema[attribute].type]
+        if (Type.depends_on) {
+            let depends_on = Type.depends_on
+            
+            if (isFunction(depends_on)) depends_on = depends_on(schema[attribute])
+            if (!Array.isArray(depends_on)) depends_on = [depends_on]
+            let dependent_values = depends_on.map(v => attributes[v] || this.readAttribute(v))
+            if (dependent_values.filter(x => x !== undefined).length != dependent_values.length) {
+                const unsettled_coercion = this._unsettled_coercions.find(x => x[0] == attribute) || [
+                    attribute, value, 0
+                ]
+                // 1 below is number of attempts, should we allow more than one attempt?
+                if (unsettled_coercion[2] > 1) { 
+                    throw new TypeError("Coercion of " + attribute + " failed because unfound dependency")
+                } else {
+                    unsettled_coercion[2] += 1
+                    this._unsettled_coercions.push(unsettled_coercion)
+                    return "__unsettled__"
+                }
+            } else {
+                this._unsettled_coercions = this._unsettled_coercions.filter(x => x[0] != attribute)
+                depends_on.forEach((attribute, index) => {
+                    attributes[attribute] = dependent_values[index]
+                })
+            }
+        }
+        
+        return Type.load(value, attribute, schema[attribute], attributes)
     }
     
     setAttribute(attribute, value) {
@@ -493,6 +532,12 @@ export default class Record extends EventBus {
                 this.setAttribute(key, value);
             }
         });
+        
+        while (this._unsettled_coercions.length > 0) {
+            this._unsettled_coercions.forEach(coercion => {
+                this.setAttribute(...coercion)
+            })
+        }
     }
 
     primaryKey() {
@@ -522,54 +567,61 @@ export default class Record extends EventBus {
 
         return base.replace(/([^\/])$/, '$1/') + encodeURIComponent(this.toParam());
     }
-
-    asJSON() {
-        let json = {};
-        let schema = this.constructor.schema;
+    
+    dumpAttributes(attributes) {
+        const dump = {};
+        const schema = this.constructor.schema;
+        const queuedDumps = []
         
-        each(this.attributes, (key, value) => {
+        const dumpAttribute = (key, value) => {
             if (schema && schema[key] && schema[key].type) {
-                if (schema[key].array) {
-                    if (value === null || value === undefined) {
-                        json[key] = null;
-                    } else {
-                        json[key] = value.map(Types.registry[schema[key].type].dump);
-                    }
-                } else if (Types.registry[schema[key].type]) {
-                    json[key] = Types.registry[schema[key].type].dump(value);
-                } else {
+                const Type = Types.registry[schema[key].type]
+                if (!Type) {
                     throw new TypeError("Coercion of " + schema[key].type + " unsupported");
                 }
+                if (Type.depends_on) {
+                    let depends_on = Type.depends_on
+                    if (isFunction(depends_on)) depends_on = depends_on(schema[key])
+                    if (!Array.isArray(depends_on)) depends_on = [depends_on]
+                    
+                    if (depends_on.length != depends_on.filter(x => Object.keys(dump).includes(x)).length) {
+                        queuedDumps.push([key, value])
+                        return
+                    }
+                }
+                if (schema[key].array) {
+                    if (value === null || value === undefined) {
+                        dump[key] = null;
+                    } else {
+                        dump[key] = value.map(v => Type.dump(v, key, schema[key], dump));
+                    }
+                } else {
+                    dump[key] = Type.dump(value, key, schema[key], dump);
+                }
             } else {
-                json[key] = value;
+                dump[key] = value;
             }
-        });
+        }
         
-        return json;
+        each(attributes, dumpAttribute);
+        queuedDumps.forEach(attrs => dumpAttribute(...attrs))
+        
+        return dump;
+    }
+
+    asJSON(attrs) {
+        return this.dumpAttributes(this.attributes);
     }
     
     attributesForSave(options) {
-        const attributes = {};
-        let schema = this.constructor.schema;
+        let attributes = {};
+        const schema = this.constructor.schema;
         
         each(this.changedAttributes(options), (key) => {
-            let value = this.attributes[key];
-            if (schema && schema[key] && schema[key].type) {
-                if (schema[key].array) {
-                    if (value === null || value === undefined) {
-                        attributes[key] = null;
-                    } else {
-                        attributes[key] = value.map(Types.registry[schema[key].type].dump);
-                    }
-                } else if (Types.registry[schema[key].type]) {
-                    attributes[key] = Types.registry[schema[key].type].dump(value);
-                } else {
-                    throw new TypeError("Coercion of " + schema[key].type + " unsupported");
-                }
-            } else {
-                attributes[key] = value;
-            }
+            attributes[key] = this.attributes[key];
         });
+        
+        attributes = this.dumpAttributes(attributes)
         
         each(this._associations, (name, association) => {
             if (association.needsSaved()) {

--- a/lib/viking/record/types/boolean.js
+++ b/lib/viking/record/types/boolean.js
@@ -1,12 +1,22 @@
 export default {
 
     // load: (value: string | boolean): boolean =>
-    load: (value) => {
-        if (typeof value === 'string') {
-            value = (value === 'true');
+    load: (value, key, changes, record, typeSettings) => {
+        const normalize = v => {
+            if (typeof v === 'string') {
+                v = (v === 'true');
+            }
+            return !!v
         }
-
-        return !!value;
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings?.array) {
+            changes[key] = value.map(normalize)
+        } else {
+            changes[key] = normalize(value)
+        }
+        
+        return true;
     },
 
     // dump: (value: boolean): any => value

--- a/lib/viking/record/types/date.js
+++ b/lib/viking/record/types/date.js
@@ -3,21 +3,32 @@ import {toISODateString} from '../../support/date';
 export default {
 
     // load: (value: string | Date | number): Date
-    load: (value) => {
-        if (typeof value === 'string') {
-            var parts = value.split("-");
-            return new Date(parts[0], parseInt(parts[1])-1, parts[2])
+    load: (value, key, changes, record, typeSettings) => {
+        const normalize = v => {
+            if (typeof v === 'string') {
+                var parts = v.split("-");
+                return new Date(parts[0], parseInt(parts[1])-1, parts[2])
+            }
+        
+            if (typeof v === 'number') {
+                return new Date(v);
+            }
+
+            if (!(v instanceof Date) && v !== null) {
+                throw new TypeError(typeof v + " can't be coerced into Date");
+            }
+            return v
         }
         
-        if (typeof value === 'number') {
-            return new Date(value);
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings?.array) {
+            changes[key] = value.map(normalize)
+        } else {
+            changes[key] = normalize(value)
         }
 
-        if (!(value instanceof Date) && value !== null) {
-            throw new TypeError(typeof value + " can't be coerced into Date");
-        }
-
-        return value;
+        return true;
     },
 
     // dump: (value: Date): string

--- a/lib/viking/record/types/datetime.js
+++ b/lib/viking/record/types/datetime.js
@@ -3,24 +3,38 @@ import {toISODateString} from '../../support/date';
 export default {
 
     // load: (value: string | Date | number): Date
-    load: (value) => {
-        if (typeof value === 'string') {
-            if(!value.match(/T\d{2}:\d{2}:\d{2}/) && value.match(/\d{4}-\d{2}-\d{2}/)){
-                return new Date(value+"T00:00:00");
-            } else {
-                return new Date(value);
+    load: (value, key, changes, record, typeSettings) => {
+        const normalize = v => {
+            if (typeof v === 'string') {
+                if(!v.match(/T\d{2}:\d{2}:\d{2}/) && v.match(/\d{4}-\d{2}-\d{2}/)){
+                    return new Date(v+"T00:00:00");
+                } else {
+                    return new Date(v);
+                }
+            }
+        
+            if (typeof v === 'number') {
+                return new Date(v);
+            }
+            
+            if (v instanceof Date) {
+                return v
+            }
+
+            if (!(v instanceof Date) && v !== null) {
+                throw new TypeError(typeof v + " can't be coerced into Date");
             }
         }
         
-        if (typeof value === 'number') {
-            return new Date(value);
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings?.array) {
+            changes[key] = value.map(normalize)
+        } else {
+            changes[key] = normalize(value)
         }
 
-        if (!(value instanceof Date) && value !== null) {
-            throw new TypeError(typeof value + " can't be coerced into Date");
-        }
-
-        return value;
+        return true;
     },
 
     // dump: (value: Date): string

--- a/lib/viking/record/types/float.js
+++ b/lib/viking/record/types/float.js
@@ -1,18 +1,25 @@
 export default {
 
     // load: function(value)
-    load: (value) => {
-        if (typeof value === 'string') {
-            if (value.trim() === '') {
-                return null;
+    load: (value, key, changes, record, typeSettings) => {
+        const normalize = v => {
+            if (typeof v === 'string') {
+                if (v.trim() === '') {
+                    return null;
+                }
             }
+            return Number(v)
         }
         
-        if (value === null || value === undefined) {
-            return value;
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings?.array) {
+            changes[key] = value.map(normalize)
+        } else {
+            changes[key] = normalize(value)
         }
 
-        return Number(value);
+        return true;
     },
 
     dump: (value) => {

--- a/lib/viking/record/types/integer.js
+++ b/lib/viking/record/types/integer.js
@@ -1,22 +1,28 @@
 export default {
 
     // load: function(value)
-    load: (value) => {
-        if (typeof value === 'string') {
-            if (value.trim() === '') {
-                return null;
+    load: (value, key, changes, record, typeSettings) => {
+        const normalize = v => {
+            if (typeof v === 'string') {
+                if (v.trim() === '') {
+                    return null;
+                }
             }
-        }
-        
-        if (value === null || value === undefined) {
-            return value;
+            return Number(v)
         }
 
-        return Number(value);
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings?.array) {
+            changes[key] = value.map(normalize)
+        } else {
+            changes[key] = normalize(value)
+        }
+
+        return true;
     },
 
     dump: (value) => {
         return value;
     }
-
 };

--- a/lib/viking/record/types/json.js
+++ b/lib/viking/record/types/json.js
@@ -5,8 +5,9 @@ export default {
             // if (value instanceof Model) {
             //     value = value.attributes;
             // }
+            changes[key] = value
 
-            return value;
+            return true;
         }
 
         throw new TypeError(typeof value + " can't be coerced into JSON");

--- a/lib/viking/record/types/string.js
+++ b/lib/viking/record/types/string.js
@@ -1,12 +1,16 @@
 export default {
 
     // load: function (value: any): string
-    load: (value) => {
-        if (typeof value !== 'string' && value !== undefined && value !== null) {
-            return String(value);
+    load: (value, key, changes, record, typeSettings) => {
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings?.array) {
+            changes[key] = value.map(v => String(v))
+        } else {
+            changes[key] = String(value)
         }
 
-        return value;
+        return true;
     },
 
     // dump: function (value: string | null | undefined): any

--- a/lib/viking/record/types/uuid.js
+++ b/lib/viking/record/types/uuid.js
@@ -1,16 +1,18 @@
 export default {
 
     // load: function (value: any): string
-    load: (value) => {
-        if (typeof value === 'string') {
-            return value;
+    load: (value, key, changes, record, typeSettings) => {
+        if (value == undefined || value == null) {
+            changes[key] = value
+        } else if (typeSettings.array) {
+            changes[key] = value
+        } else if (typeof value == "string") {
+            changes[key] = String(value)
+        } else {
+            throw new TypeError(typeof value + " can't be coerced into UUID");
         }
         
-        if (value === undefined || value === null) {
-            return value;
-        }
-        
-        throw new TypeError(typeof value + " can't be coerced into UUID");
+        return true;
     },
 
     // dump: function (value: string | null | undefined): any

--- a/test/record/types/booleanTest.js
+++ b/test/record/types/booleanTest.js
@@ -6,31 +6,27 @@ describe('Viking.Record.Types', () => {
     describe('Boolean', () => {
 
         it("::load coerces the string 'true' to true", function() {
-            assert.strictEqual(
-                BooleanType.load("true"),
-                true
-            );
+            const changes = {}
+            BooleanType.load("true", 'foo', changes)
+            assert.equal(true, changes.foo)
         });
 
         it("::load coerces the string 'false' to false", function() {
-            assert.strictEqual(
-                BooleanType.load("false"),
-                false
-            );
+            const changes = {}
+            BooleanType.load("false", 'foo', changes)
+            assert.equal(false, changes.foo)
         });
 
         it("::load coerces true to true", function() {
-            assert.strictEqual(
-                BooleanType.load(true),
-                true
-            );
+            const changes = {}
+            BooleanType.load(true, 'foo', changes)
+            assert.equal(true, changes.foo)
         });
 
         it("::load coerces false to false", function() {
-            assert.strictEqual(
-                BooleanType.load(false),
-                false
-            );
+            const changes = {}
+            BooleanType.load(false, 'foo', changes)
+            assert.equal(false, changes.foo)
         });
 
         it("::dump true", function() {

--- a/test/record/types/customTypeTest.js
+++ b/test/record/types/customTypeTest.js
@@ -8,76 +8,24 @@ import Types from 'viking/record/types';
 describe('Viking.Record.Types', () => {
     
     describe('custom', () => {
-        Types.registry.duration = {
-            load: (value, key, schema, attrs) => {
-                return {
-                    value: value,
-                    units: 'milliseconds'
-                }
-            },
-            dump: (v, key, schema, attrs) => {
-                return v.value + " " + v.units
-            }
-        }
-    
-        class Foo extends Record {
-            static schema = {
-                job_length: {type: 'duration'}
-            }
-        }
-
-        it("init", () => {
-            const record = new Foo({
-                job_length: 9000,
-            })
-            
-            assert.deepEqual({
-                value: 9000,
-                units: 'milliseconds'
-            }, record.job_length);
-        });
-        
-        it("asJSON", () => {
-            const record = new Foo({
-                job_length: 9000,
-            })
-            
-            record.job_length.value = 9
-            record.job_length.units = 'minutes'
-            
-            assert.deepEqual({
-                job_length: "9 minutes"
-            }, record.asJSON())
-        });
-        
-        it("setAttribute", () => {
-            const record = new Foo({
-                job_length: 9,
-            })
-            
-            record.job_length = 8000
-            
-            assert.deepEqual({
-                job_length: "8000 milliseconds"
-            }, record.asJSON())
-        });
-    })
-    
-    describe('custom with depends_on', () => {
         
         Types.registry.length = {
-            depends_on: schema => {
-                return schema.units_key
-            },
-            load: (value, key, schema, attrs) => {
-                if (typeof value == "object") return value
-                return {
-                    value: value,
-                    units: attrs[schema.units_key]
+            load: (value, key, changes, record, typeSettings) => {
+                const units = changes[typeSettings.units_key] || record.attributes[typeSettings.units_key]
+                if (!units) {
+                    return false
                 }
+                if (typeof value != "object") value = {
+                    value,
+                    units
+                }
+
+                changes[key] = value
+                changes[typeSettings.units_key] = value.units
+                
+                return true
             },
-            dump: (v, key, schema, attrs) => {
-                attrs[schema.units_key] = v.units
+            dump: (v, key) => {
                 return v.value
             }
         }
@@ -100,22 +48,22 @@ describe('Viking.Record.Types', () => {
             }, record.foo_width);
         });
         
-        it("asJSON", () => {
+        it("setting attribute", () => {
             const record = new Foo({
                 foo_width: 9,
                 foo_width_units: 'ft'
             })
             
-            record.foo_width.value = 3
-            record.foo_width.units = 'm'
+            record.foo_width = {
+                value: 3,
+                units: 'm'
+            }
             
-            assert.deepEqual({
-                foo_width: 3,
-                foo_width_units: 'm'
-            }, record.asJSON())
+            assert.equal(3, record.foo_width.value)
+            assert.equal('m', record.readAttribute('foo_width_units'))
         });
         
-        it("setAttribute", () => {
+        it("asJSON", () => {
             const record = new Foo({
                 foo_width: 9,
                 foo_width_units: 'ft'
@@ -130,36 +78,6 @@ describe('Viking.Record.Types', () => {
                 foo_width: 3,
                 foo_width_units: 'm'
             }, record.asJSON())
-        });
-        
-        it("depends_on is string", () => {
-            Types.registry.area = {
-                depends_on: 'area_units',
-                load: (value, key, schema, attrs) => {
-                    if (typeof value == "object") return value
-                    return {
-                        value: value,
-                        units: attrs.area_units
-                    }
-                },
-                dump: (v, key, schema, attrs) => {
-                    attrs.area_units = v.units
-                    return v.value
-                }
-            }
-            class Bar extends Record {
-                static schema = {
-                    bar_area: {type: 'area'}
-                }
-            }
-            const record = new Bar({
-                bar_area: 9,
-                area_units: 'ft'
-            })
-            assert.deepEqual({
-                value: 9,
-                units: 'ft'
-            }, record.bar_area);
         });
 
     });

--- a/test/record/types/customTypeTest.js
+++ b/test/record/types/customTypeTest.js
@@ -1,0 +1,166 @@
+import 'mocha';
+import * as assert from 'assert';
+import JSONType from 'viking/record/types/json';
+import Record from 'viking/record';
+import Types from 'viking/record/types';
+
+
+describe('Viking.Record.Types', () => {
+    
+    describe('custom', () => {
+        Types.registry.duration = {
+            load: (value, key, schema, attrs) => {
+                return {
+                    value: value,
+                    units: 'milliseconds'
+                }
+            },
+            dump: (v, key, schema, attrs) => {
+                return v.value + " " + v.units
+            }
+        }
+    
+        class Foo extends Record {
+            static schema = {
+                job_length: {type: 'duration'}
+            }
+        }
+
+        it("init", () => {
+            const record = new Foo({
+                job_length: 9000,
+            })
+            
+            assert.deepEqual({
+                value: 9000,
+                units: 'milliseconds'
+            }, record.job_length);
+        });
+        
+        it("asJSON", () => {
+            const record = new Foo({
+                job_length: 9000,
+            })
+            
+            record.job_length.value = 9
+            record.job_length.units = 'minutes'
+            
+            assert.deepEqual({
+                job_length: "9 minutes"
+            }, record.asJSON())
+        });
+        
+        it("setAttribute", () => {
+            const record = new Foo({
+                job_length: 9,
+            })
+            
+            record.job_length = 8000
+            
+            assert.deepEqual({
+                job_length: "8000 milliseconds"
+            }, record.asJSON())
+        });
+    })
+    
+    describe('custom with depends_on', () => {
+        
+        Types.registry.length = {
+            depends_on: schema => {
+                return schema.units_key
+            },
+            load: (value, key, schema, attrs) => {
+                if (typeof value == "object") return value
+                return {
+                    value: value,
+                    units: attrs[schema.units_key]
+                }
+            },
+            dump: (v, key, schema, attrs) => {
+                attrs[schema.units_key] = v.units
+                return v.value
+            }
+        }
+    
+        class Foo extends Record {
+            static schema = {
+                foo_width: {type: 'length', units_key: 'foo_width_units'}
+            }
+        }
+
+        it("init", () => {
+            const record = new Foo({
+                foo_width: 9,
+                foo_width_units: 'ft'
+            })
+            
+            assert.deepEqual({
+                value: 9,
+                units: 'ft'
+            }, record.foo_width);
+        });
+        
+        it("asJSON", () => {
+            const record = new Foo({
+                foo_width: 9,
+                foo_width_units: 'ft'
+            })
+            
+            record.foo_width.value = 3
+            record.foo_width.units = 'm'
+            
+            assert.deepEqual({
+                foo_width: 3,
+                foo_width_units: 'm'
+            }, record.asJSON())
+        });
+        
+        it("setAttribute", () => {
+            const record = new Foo({
+                foo_width: 9,
+                foo_width_units: 'ft'
+            })
+            
+            record.foo_width = {
+                value: 3,
+                units: 'm'
+            }
+            
+            assert.deepEqual({
+                foo_width: 3,
+                foo_width_units: 'm'
+            }, record.asJSON())
+        });
+        
+        it("depends_on is string", () => {
+            Types.registry.area = {
+                depends_on: 'area_units',
+                load: (value, key, schema, attrs) => {
+                    if (typeof value == "object") return value
+                    return {
+                        value: value,
+                        units: attrs.area_units
+                    }
+                },
+                dump: (v, key, schema, attrs) => {
+                    attrs.area_units = v.units
+                    return v.value
+                }
+            }
+            class Bar extends Record {
+                static schema = {
+                    bar_area: {type: 'area'}
+                }
+            }
+            const record = new Bar({
+                bar_area: 9,
+                area_units: 'ft'
+            })
+            assert.deepEqual({
+                value: 9,
+                units: 'ft'
+            }, record.bar_area);
+        });
+
+    });
+});

--- a/test/record/types/dateTest.js
+++ b/test/record/types/dateTest.js
@@ -7,41 +7,49 @@ describe('Viking.Record.Types', () => {
 
         it("::load thows error when can't coerce value", function() {
             assert.throws(function() { DateType.load(true) }, TypeError);
-
+            const changes = {}
             try {
-                DateType.load(true);
+                DateType.load(true, 'foo', changes);
             } catch (e) {
                 assert.equal(e.message, "boolean can't be coerced into Date");
             }
         });
 
         it("::load coerces iso8601 string to date", function() {
+            const changes = {}
+            DateType.load("2013-04-10", 'foo', changes)
             assert.deepEqual(
-                DateType.load("2013-04-10"),
+                changes.foo,
                 new Date(1365570000000)
             );
-
+            
+            DateType.load("2013-04-10", 'foo', changes)
             assert.equal(
-                DateType.load("2013-04-10").valueOf(),
+                changes.foo.valueOf(),
                 (new Date(1365570000000)).valueOf()
             );
         });
 
         it("::load coerces int(milliseconds since epoch) to date", function() {
+            const changes = {}
+            DateType.load(1365629126097, 'foo', changes)
             assert.deepEqual(
-                DateType.load(1365629126097),
+                changes.foo,
                 new Date(1365629126097)
             );
-
+            
+            DateType.load(1365629126097, 'foo', changes)
             assert.equal(
-                DateType.load(1365629126097).valueOf(),
+                changes.foo.valueOf(),
                 (new Date(1365629126097)).valueOf()
             );
         });
 
         it("::load coerces date to date", function() {
+            const changes = {}
+            DateType.load(new Date(1365629126097), 'foo', changes)
             assert.equal(
-                DateType.load(new Date(1365629126097)).valueOf(),
+                changes.foo.valueOf(),
                 (new Date(1365629126097)).valueOf()
             );
         });

--- a/test/record/types/datetimeTypeTest.js
+++ b/test/record/types/datetimeTypeTest.js
@@ -9,39 +9,48 @@ describe('Viking.Record.Types', () => {
             assert.throws(function() { DateTimeType.load(true) }, TypeError);
 
             try {
-                DateTimeType.load(true);
+                DateTimeType.load(true, 'foo', {});
             } catch (e) {
                 assert.equal(e.message, "boolean can't be coerced into Date");
             }
         });
 
         it("::load coerces iso8601 string to date", function() {
+            const changes = {}
+            
+            DateTimeType.load("2013-04-10T21:24:28+00:00", 'foo', changes)
             assert.deepEqual(
-                DateTimeType.load("2013-04-10T21:24:28+00:00"),
+                changes.foo,
                 new Date(1365629068000)
             );
 
+            DateTimeType.load("2013-04-10T21:24:28+00:00", 'foo', changes)
             assert.equal(
-                DateTimeType.load("2013-04-10T21:24:28+00:00").valueOf(),
+                changes.foo.valueOf(),
                 (new Date(1365629068000)).valueOf()
             );
         });
 
         it("::load coerces int(milliseconds since epoch) to date", function() {
+            const changes = {}
+            DateTimeType.load(1365629126097, 'foo', changes)
             assert.deepEqual(
-                DateTimeType.load(1365629126097),
+                changes.foo,
                 new Date(1365629126097)
             );
 
+            DateTimeType.load(1365629126097, 'foo', changes)
             assert.equal(
-                DateTimeType.load(1365629126097).valueOf(),
+                changes.foo.valueOf(),
                 (new Date(1365629126097)).valueOf()
             );
         });
 
         it("::load coerces date to date", function() {
+            const changes = {}
+            DateTimeType.load(new Date(1365629126097), 'foo', changes)
             assert.equal(
-                DateTimeType.load(new Date(1365629126097)).valueOf(),
+                changes.foo.valueOf(),
                 (new Date(1365629126097)).valueOf()
             );
         });

--- a/test/record/types/floatTypeTest.js
+++ b/test/record/types/floatTypeTest.js
@@ -6,24 +6,35 @@ describe('Viking.Record.Types', () => {
     describe('Float', () => {
 
         it("::load coerces number to number", () => {
-            assert.equal(FloatType.load(10.5),  10.5);
+            const changes = {}
+            FloatType.load(10.5, 'foo', changes)
+            assert.equal(changes.foo,  10.5);
         });
 
         it("::load coerces string to number", () => {
-            assert.equal(FloatType.load('10.5'), 10.5);
+            const changes = {}
+            FloatType.load('10.5', 'foo', changes)
+            assert.equal(changes.foo, 10.5);
         });
 
         it("::load coerces empty string to null", () => {
-            assert.equal(FloatType.load(' '),   null);
-            assert.equal(FloatType.load(''),    null);
+            const changes = {}
+            FloatType.load(' ', 'foo', changes)
+            assert.equal(changes.foo, null);
+            FloatType.load('', 'foo', changes)
+            assert.equal(changes.foo, null);
         });
         
         it("::load coerces null to null", () => {
-            assert.equal(FloatType.load(null), 	null);
+            const changes = {}
+            FloatType.load(null, 'foo', changes)
+            assert.equal(changes.foo, null);
         });
         
         it("::load coerces undefined to undefined", () => {
-            assert.equal(FloatType.load(undefined), 	undefined);
+            const changes = {}
+            FloatType.load(undefined, 'foo', changes)
+            assert.equal(changes.foo, undefined);
         });
 
         it("::dump coerces number to number", () => {

--- a/test/record/types/integerTypeTest.js
+++ b/test/record/types/integerTypeTest.js
@@ -6,26 +6,39 @@ describe('Viking.Record.Types', () => {
     describe('Integer', () => {
 
         it("::load coerces number to number", () => {
-            assert.equal(IntegerType.load(10),     10);
-            assert.equal(IntegerType.load(10.5),   10.5);
+            const changes = {};
+            IntegerType.load(10, 'foo', changes)
+            assert.equal(changes.foo,     10);
+            IntegerType.load(10.5, 'foo', changes)
+            assert.equal(changes.foo,   10.5);
         });
 
         it("::load coerces string to number", () => {
-            assert.equal(IntegerType.load('10'),   10);
-            assert.equal(IntegerType.load('10.5'), 10.5);
+            const changes = {};
+            IntegerType.load('10', 'foo', changes)
+            assert.equal(changes.foo,   10);
+            IntegerType.load('10.5', 'foo', changes)
+            assert.equal(changes.foo, 10.5);
         });
 
         it("::load coerces empty string to null", () => {
-            assert.equal(IntegerType.load(' '),   	null);
-            assert.equal(IntegerType.load(''), 	null);
+            const changes = {};
+            IntegerType.load(' ', 'foo', changes)
+            assert.equal(changes.foo,   	null);
+            IntegerType.load('', 'foo', changes)
+            assert.equal(changes.foo, 	null);
         });
         
         it("::load coerces null to null", () => {
-            assert.equal(IntegerType.load(null), 	null);
+            const changes = {};
+            IntegerType.load(null, 'foo', changes)
+            assert.equal(changes.foo, 	null);
         });
         
         it("::load coerces undefined to undefined", () => {
-            assert.equal(IntegerType.load(undefined), 	undefined);
+            const changes = {};
+            IntegerType.load(undefined, 'foo', changes)
+            assert.equal(changes.foo, undefined);
         });
 
         it("::dump coerces number to number", () => {

--- a/test/record/types/jsonTypeTest.js
+++ b/test/record/types/jsonTypeTest.js
@@ -6,8 +6,11 @@ describe('Viking.Record.Types', () => {
     describe('JSON', () => {
 
         it("::load coerces {} to Viking.Record", () => {
-            assert.deepEqual(JSONType.load({}), {});
-            assert.deepEqual(JSONType.load({key: 'value'}), {key: 'value'});
+            const changes = {}
+            JSONType.load({}, 'foo', changes)
+            assert.deepEqual(changes.foo, {});
+            JSONType.load({key: 'value'}, 'foo', changes)
+            assert.deepEqual(changes.foo, {key: 'value'});
         });
 
         // it("::load coerces {} to Viking.Model with modelName set to key", function() {

--- a/test/record/types/stringTypeTest.js
+++ b/test/record/types/stringTypeTest.js
@@ -6,21 +6,31 @@ describe('Viking.Record.Types', () => {
     describe('String', () => {
 
         it("::load coerces boolean to string", function() {
-            assert.equal(StringType.load(true), 'true');
-            assert.equal(StringType.load(false), 'false');
+            const changes = {}
+            StringType.load(true, 'foo', changes)
+            assert.equal(changes.foo, 'true');
+            StringType.load(false, 'foo', changes)
+            assert.equal(changes.foo, 'false');
         });
 
         it("::load coerces number to string", function() {
-            assert.equal(StringType.load(10), '10');
-            assert.equal(StringType.load(10.5), '10.5');
+            const changes = {}
+            StringType.load(10, 'foo', changes)
+            assert.equal(changes.foo, '10');
+            StringType.load(10.5, 'foo', changes)
+            assert.equal(changes.foo, '10.5');
         });
 
         it("::load coerces null to string", function() {
-            assert.equal(StringType.load(null), null);
+            const changes = {}
+            StringType.load(null, 'foo', changes)
+            assert.equal(changes.foo, null);
         });
 
         it("::load coerces undefined to string", function() {
-            assert.equal(StringType.load(undefined), undefined);
+            const changes = {}
+            StringType.load(undefined, 'foo', changes)
+            assert.equal(changes.foo, undefined);
         });
 
         // it("::dump coerces boolean to string", function() {


### PR DESCRIPTION
Change `Type.load` to alter changes in place, so that type can change other keys than just it's type.

Enables Types like Area that loads and dumps to keys on the record:
```javascript
Types.registry.length = {
    load: (value, key, changes, record, typeSettings) => {
        const units = changes[typeSettings.units_key]
        if (!units) {
            return false
        }
        if (typeof value != "object") value = {
            value,
            units
        }

        changes[key] = value
        changes[typeSettings.units_key] = value.units
        
        return true
    },
    dump: (v, key) => {
        return v.value
    }
}
```