### PR TITLE
Update JSON Type to bubble up changes

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -416,11 +416,21 @@ export default class Record extends EventBus {
     
     // setAttributes(attributes: object)
     setAttributes(attributes, coerced=false) {
+        let changes = {};
+        // let chaning = this._changing;
+        // this._changing = true;
+
+        // if (!chaning) {
+        //     this._previousAttributes = _.clone(this.attributes);
+        //     this.changed = {};
+        // }
+        // let current = this.attributes;
+        // let changed = this.changed;
+        // let prev = this._previousAttributes;
         if (!coerced) {
             this.coerceAttributes(attributes);
         }
 
-        let changes = {};
         each(attributes, (key, value) => {
             if (!(key in this.attributes) || !isEqual(this.attributes[key], value)) {
                 changes[key] = [this.attributes[key], value];
@@ -439,6 +449,26 @@ export default class Record extends EventBus {
                 this.dispatchEvent('changed:' + key, this, ...changes[key]);
             }
         })
+        // TODO: if id not defined in schema add?
+        // if (this.constructor.primaryKey in attributes) {
+        //     this.id = this.readAttribute(this.constructor.primaryKey);
+        // }
+
+        // Trigger all relevant attribute changes.
+
+        // You might be wondering why there's a `while` loop here. Changes can
+        // be recursively nested within `"change"` events.
+        // if (changing) { return this; }
+            // while (this._pending) {
+            //     options = this._pending;
+            //     this._pending = false;
+                if(Object.keys(changes).length > 0) {
+                    this.dispatchEvent('changed', this, changes); //, options
+                }
+            // }
+
+        // this._pending = false;
+        // this._changing = false;
         if (Object.keys(changes).length > 0) {
             this.dispatchEvent('changed', this, changes); //, options
         }

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -469,9 +469,6 @@ export default class Record extends EventBus {
 
         // this._pending = false;
         // this._changing = false;
-        if (Object.keys(changes).length > 0) {
-            this.dispatchEvent('changed', this, changes); //, options
-        }
         return this;
     }
     

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -347,6 +347,7 @@ export default class Record extends EventBus {
     persist() {
         this._new_record = false;
         this._changes = {};
+        return this;
     }
 
     isNewRecord() {
@@ -414,20 +415,12 @@ export default class Record extends EventBus {
     }
     
     // setAttributes(attributes: object)
-    setAttributes(attributes) {
+    setAttributes(attributes, coerced=false) {
+        if (!coerced) {
+            this.coerceAttributes(attributes);
+        }
+
         let changes = {};
-        // let chaning = this._changing;
-        // this._changing = true;
-
-        // if (!chaning) {
-        //     this._previousAttributes = _.clone(this.attributes);
-        //     this.changed = {};
-        // }
-
-        // let current = this.attributes;
-        // let changed = this.changed;
-        // let prev = this._previousAttributes;
-        this.coerceAttributes(attributes);
         each(attributes, (key, value) => {
             if (!(key in this.attributes) || !isEqual(this.attributes[key], value)) {
                 changes[key] = [this.attributes[key], value];
@@ -446,26 +439,9 @@ export default class Record extends EventBus {
                 this.dispatchEvent('changed:' + key, this, ...changes[key]);
             }
         })
-        // TODO: if id not defined in schema add?
-        // if (this.constructor.primaryKey in attributes) {
-        //     this.id = this.readAttribute(this.constructor.primaryKey);
-        // }
-
-        // Trigger all relevant attribute changes.
-        
-        // You might be wondering why there's a `while` loop here. Changes can
-        // be recursively nested within `"change"` events.
-        // if (changing) { return this; }
-            // while (this._pending) {
-            //     options = this._pending;
-            //     this._pending = false;
-                if(Object.keys(changes).length > 0) {
-                    this.dispatchEvent('changed', this, changes); //, options
-                }
-            // }
-
-        // this._pending = false;
-        // this._changing = false;
+        if (Object.keys(changes).length > 0) {
+            this.dispatchEvent('changed', this, changes); //, options
+        }
         return this;
     }
     

--- a/lib/viking/record/types/json.js
+++ b/lib/viking/record/types/json.js
@@ -1,32 +1,47 @@
 import Type from '../type';
+import {isEqual, deepAssign} from '../../support';
 
 export default class JSONType extends Type {
     
-    // load(value: any)
-    static load(value) {
-        if (typeof value === 'object') {
-            // if (value instanceof Model) {
-            //     value = value.attributes;
-            // }
-
-            return value;
+    static set(key, value, inObject, record, typeSettings) {
+        if (value == undefined || value == null) {
+            inObject[key] = value;
+        } else if (typeof value === 'object') {
+            inObject[key] = this.deepProxy(value, record, key);
+        } else {
+            throw new TypeError(typeof value + " can't be coerced into JSON");
         }
-
-        throw new TypeError(typeof value + " can't be coerced into JSON");
+        
+        return true;
     }
 
     static dump(value) {
-        // if (value instanceof Model) {
-        //     const output = value.toJSON();
-        //     _.each(output, (v, k) => {
-        //         if (v instanceof Model) {
-        //             output[k] = JSONType.dump(v);
-        //         }
-        //     });
-        //     return output;
-        // }
-
         return value;
     }
-
+    
+    static deepProxy(obj, record, rootAttribute) {
+        if (Array.isArray(obj)) {
+            return obj.map(x => this.deepProxy(x, record, rootAttribute))
+        } else if (typeof obj == "object") {
+            Object.keys(obj).forEach(key => {
+                obj[key] = this.deepProxy(obj[key], record, rootAttribute)
+            })
+            return new Proxy(obj, {
+                get: (target, name) => target[name], // may not be necessary
+                set: (target, name, value) => {
+                    if (isEqual(target[name], value)){
+                        target[name] = this.deepProxy(value, record, rootAttribute)
+                    } else {
+                        const rootObject = record[rootAttribute]
+                        record.attributes[rootAttribute] = deepAssign({}, rootObject)
+                        target[name] = this.deepProxy(value, record, rootAttribute)
+                        record.setAttributes({[rootAttribute]: rootObject}, true)
+                    }
+                    return true
+                }
+            })
+        } else {
+            return obj
+        }
+    }
 };

--- a/lib/viking/record/types/json.js
+++ b/lib/viking/record/types/json.js
@@ -27,7 +27,6 @@ export default class JSONType extends Type {
                 obj[key] = this.deepProxy(obj[key], record, rootAttribute)
             })
             return new Proxy(obj, {
-                get: (target, name) => target[name], // may not be necessary
                 set: (target, name, value) => {
                     if (isEqual(target[name], value)){
                         target[name] = this.deepProxy(value, record, rootAttribute)

--- a/lib/viking/support/object.js
+++ b/lib/viking/support/object.js
@@ -44,10 +44,23 @@ export function pick(object, ...keys) {
 
 export function deepAssign (target, ...objects) {
     objects.forEach(object => {
-        if (isPlainObject(object)) {
+        if (Array.isArray(object)) {
+            target.length = 0
+            object.forEach((o, i) => {
+                if (Array.isArray(o)) {
+                    target[i] = deepAssign([], o)
+                } else if (isPlainObject(o)) {
+                    target[i] = deepAssign({}, o)
+                } else {
+                    target[i] = o
+                }
+            })
+        } else if (isPlainObject(object)) {
             Object.keys(object).forEach(key => {
                 const value = object[key]
-                if (isPlainObject(target[key]) &&  isPlainObject(value)) {
+                if (Array.isArray(value)) {
+                    target[key] = deepAssign([], value)
+                } else if (isPlainObject(target[key]) && isPlainObject(value)) {
                     target[key] = deepAssign(target[key], value)
                 } else if (isPlainObject(value)) {
                     target[key] = deepAssign({}, value)

--- a/test/record/types/jsonTypeTest.js
+++ b/test/record/types/jsonTypeTest.js
@@ -28,6 +28,15 @@ describe('Viking.Record.Types', () => {
             }
         });
         
+        // it("::load coerces {} to Viking.Model with modelName set to key", function() {
+        //     assert.equal(JSONType.load({}, 'key').modelName.name, 'Key');
+        // });
+        
+        // it("::load coerces {} to Viking.Model with baseModel set to the JSON object", function() {
+        //     var attribute = JSONType.load({}, 'key');
+        //     assert.strictEqual(attribute.baseModel, attribute);
+        // });
+        
         describe("changes", () => {
 
             it("first level key", () => {

--- a/test/record/types/jsonTypeTest.js
+++ b/test/record/types/jsonTypeTest.js
@@ -1,33 +1,122 @@
 import 'mocha';
 import * as assert from 'assert';
 import JSONType from 'viking/record/types/json';
+import Record from 'viking/record';
 
 describe('Viking.Record.Types', () => {
     describe('JSON', () => {
-
-        it("::load coerces {} to Viking.Record", () => {
-            assert.deepEqual(JSONType.load({}), {});
-            assert.deepEqual(JSONType.load({key: 'value'}), {key: 'value'});
-        });
-
-        // it("::load coerces {} to Viking.Model with modelName set to key", function() {
-        //     assert.equal(JSONType.load({}, 'key').modelName.name, 'Key');
-        // });
+        class Actor extends Record {
+            static schema = {
+                preferences: {type: "json", default: {}}
+            }
+        }
         
-        // it("::load coerces {} to Viking.Model with baseModel set to the JSON object", function() {
-        //     var attribute = JSONType.load({}, 'key');
-        //     assert.strictEqual(attribute.baseModel, attribute);
-        // });
+        it("coerces {} to Viking.Record", () => {
+            let model = new Actor({preferences: {}})
+            assert.deepEqual(model.preferences, {});
+            model = new Actor({preferences: {key: 'value'}})
+            assert.deepEqual(model.preferences, {key: 'value'});
+        });
     
-        it("::load thows error when can't coerce value", function() {
-            assert.throws(() => { JSONType.load(true); }, TypeError);
+        it("thows error when can't coerce value", function() {
+            assert.throws(() => { new Actor({preferences: true}) }, TypeError);
     
             try {
-                JSONType.load(true)
+                new Actor({preferences: true})
             } catch (e) {
                 assert.equal(e.message, "boolean can't be coerced into JSON");
             }
         });
+        
+        describe("changes", () => {
+
+            it("first level key", () => {
+                let model = new Actor({preferences: {fruit: 'apple', water: 'still'}}).persist()
+
+                model.preferences.fruit = 'orange'
+                assert.deepEqual(model.changes(), {
+                    preferences: [
+                        {fruit: 'apple', water: 'still'},
+                        {fruit: 'orange', water: 'still'}
+                    ]
+                });
+
+                model.preferences.fruit = 'apple'
+                assert.deepEqual(model.changes(), {});
+            })
+            
+            it("low level key", () => {
+                const model = new Actor({preferences: {fruit: {green_room: 'apple'}, water: 'still'}}).persist()
+
+                model.preferences.fruit.green_room = 'orange'
+                assert.deepEqual(model.changes(), {
+                    preferences: [
+                        {fruit: {green_room: 'apple'}, water: 'still'},
+                        {fruit: {green_room: 'orange'}, water: 'still'}
+                    ]
+                });
+
+                model.preferences.fruit.green_room = 'apple'
+                assert.deepEqual(model.changes(), {});
+            })
+  
+            it("array", () => {
+                let model = new Actor({preferences: {fruit: 'apple', agents: ["Rod", "Jerry"]}}).persist()
+
+                model.preferences.agents = ["Rod", "Jerry", "Kim"]
+                assert.deepEqual(model.changes(), {
+                    preferences: [
+                        {fruit: 'apple', agents: ["Rod", "Jerry"]},
+                        {fruit: 'apple', agents: ["Rod", "Jerry", "Kim"]}
+                    ]
+                });
+
+                model.preferences.agents = ["Rod", "Jerry"]
+                assert.deepEqual(model.changes(), {});
+
+                model = new Actor({preferences: {
+                    agents: [{
+                        name: "Jerry",
+                        region: "CA"
+                    }, {
+                        name: "Rod",
+                        region: "TX"
+                    }]
+                }}).persist()
+
+                const agent = model.preferences.agents.find(x => x.name == "Jerry")
+                agent.region = "CA,WA"
+
+                assert.deepEqual(model.changes(), {
+                    preferences: [
+                        {
+                            agents: [{
+                                name: "Jerry",
+                                region: "CA"
+                            }, {
+                                name: "Rod",
+                                region: "TX"
+                            }]
+                        },{
+                            agents: [{
+                                name: "Jerry",
+                                region: "CA,WA"
+                            }, {
+                                name: "Rod",
+                                region: "TX"
+                            }]
+                        }
+                    ]
+                });
+
+                agent.region = "CA"
+                assert.deepEqual(model.changes(), {});
+            })
+  //
+  //           it("array.push")
+  //
+  //           it("array.remove")
+        })
         
         // it("::load doesn't use the type key for STI", function () {
         //     assert.deepEqual(JSONType.load({type: 'my_value'}).attributes, {type: 'my_value'});

--- a/test/support/objectTest.js
+++ b/test/support/objectTest.js
@@ -41,6 +41,57 @@ describe('VikingSupport.Object', () => {
             },
             c: 3
         });
+        
+        assert.deepEqual(
+            deepAssign({test: [1,2], bar: 2}, {test: [3,4]}),
+            {test: [3,4], bar: 2}
+        );
+        
+        assert.deepEqual(
+            deepAssign({test: {bar: [1,2]}}, {test: {bar: [3,4]}}),
+            {test: {bar: [3,4]}}
+        );
+        
+        assert.deepEqual(
+            deepAssign({test: {bar: [[1],[2]]}}, {test: {bar: [[3],[4]]}}),
+            {test: {bar: [[3],[4]]}}
+        );
+        
+        const foo = {agents: [{
+            name: "Jerry",
+            status: 'active'
+        }, {
+            name: "Rob",
+            status: 'active'
+        }]}
+        const was = deepAssign({}, foo)
+        foo.agents.find(x => x.name == "Jerry").status = "inactive"
+        
+        assert.deepEqual(
+            was,
+            {
+                agents: [{
+                        name: "Jerry",
+                        status: 'active'
+                    }, {
+                        name: "Rob",
+                        status: 'active'
+                }]
+            }
+        );
+        
+        assert.deepEqual(
+            foo,
+            {
+                agents: [{
+                        name: "Jerry",
+                        status: 'inactive'
+                    }, {
+                        name: "Rob",
+                        status: 'active'
+                }]
+            }
+        );
     });
 
 });


### PR DESCRIPTION
updates json type to allow mutation of json object to bubble up changes to the record.

```javascript
let model = new Actor({preferences: {fruit: 'apple'}}).persist()
model.preferences.fruit = 'orange'
model.changes() // => {preferences: [{fruit: 'apple'},{fruit: 'orange'}]}
```