### PR TITLE
allow schema types to be functions to dynamically set type

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -394,7 +394,13 @@ export default class Record extends EventBus {
         
         const coerceAttribute = (key, value) => {
             if (schema && schema[key] && schema[key].type) {
-                const Type = Types.registry[schema[key].type];
+                let type = schema[key].type
+                if (isFunction(type)) {
+                    type = type(this, changes)
+                    if (type === false)
+                    return queue.push([key, value]);
+                }
+                const Type = Types.registry[type];
                 if (Type) {
                     if (Type.set(key, value, changes, this, schema[key]) === false) {
                         queue.push([key, value]);
@@ -530,7 +536,11 @@ export default class Record extends EventBus {
         
         each(attributes, (key, value) => {
             if (schema && schema[key] && schema[key].type) {
-                const Type = Types.registry[schema[key].type]
+                let type = schema[key].type
+                if (isFunction(type)) {
+                    type = type(this)
+                }
+                const Type = Types.registry[type]
                 if (!Type) {
                     throw new TypeError("Coercion of " + schema[key].type + " unsupported");
                 }

--- a/test/record/types/dynamicTypeTest.js
+++ b/test/record/types/dynamicTypeTest.js
@@ -1,0 +1,60 @@
+import 'mocha';
+import * as assert from 'assert';
+import Record from 'viking/record';
+
+describe('Viking.Record.Types', () => {
+    
+    describe('custom', () => {
+    
+        class Foo extends Record {
+            static schema = {
+                value: {type: (r, changes={}) => {
+                    return changes.type || r.readAttribute('type')
+                }}
+            }
+        }
+
+        it("init", () => {
+            let record = new Foo({
+                type: 'integer',
+                value: 9
+            })
+            assert.deepEqual(9, record.value);
+            
+            record = new Foo({
+                value: 9,
+                type: 'string'
+            })
+            assert.deepEqual('9', record.value);
+            
+            record = new Foo({
+                type: 'boolean',
+                value: 9
+            })
+            assert.deepEqual(true, record.value);
+        });
+        
+        it("setting attribute", () => {
+            const record = new Foo({
+                value: 9,
+                type: 'string'
+            })
+
+            record.value = 3
+            assert.deepEqual('3', record.value);
+        });
+
+        it("asJSON", () => {
+            const record = new Foo({
+                value: 9,
+                type: 'string'
+            })
+
+            assert.deepEqual({
+                type: 'string',
+                value: '9'
+            }, record.asJSON())
+        });
+
+    });
+});


### PR DESCRIPTION
Enable setting type in schema dynamically
```javascript
class Foo extends Record {
    static schema = {
        value: {
            type: (r, changes={}) => changes.type || r.readAttribute('type')
        }
    }
}
```