### PR TITLE
Add afterResponse event to relation

### DIFF
--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -14,6 +14,7 @@ import Connection from './connection';
  * | afterAdd   | record(s) added             | record(s)_added          |
  * | afterRemove | record(s) removed           | record(s)_removed        |
  * | beforeLoad  | about to (re)load record(s) | record(s)                |
+ * | afterResponse | after load before instantiation of target, response is used during instantiation | response:Array |
  * | afterLoad  | record(s) loaded            | record(s)                |
  * | *       | any event                   | event_name, ...arguments |
  * | changed | an attribute of the relation was changed | attribute, new_value |
@@ -138,6 +139,7 @@ export default class Relation extends EventBus {
             this.loaded = true;
             this.loading = false;
 
+            this.dispatchEvent('afterResponse', response)
             if (this._calculate) {
                 this.target = response;
             } else {

--- a/test/record/relationTest.js
+++ b/test/record/relationTest.js
@@ -56,6 +56,23 @@ describe('Viking.Relation', () => {
             });
         })
         
+        it('afterResponse', function (done) {
+            const relation = Model.where({parent_id: 11})
+
+            relation.addEventListener('afterResponse', response => {
+                response[0].name = "foo"
+            });
+            relation.addEventListener('afterAdd', records => {
+                assert.deepEqual(records.map(x => x.readAttribute('name')), ['foo']);
+            });
+            
+            relation.load().then(() => done(), done)
+            
+            this.withRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1}]');
+            });
+        })
+        
         it('afterLoad', function (done) {
             const relation = Model.where({parent_id: 11})
 


### PR DESCRIPTION
Support modification of response once received; before the records are instantiated.

```javascript
relation = Model.where(...)
relation.addEventListener('afterResponse', response => {
    response[0]['name'] = 'new Name';
});
relation.first().name // => 'new Name';
```