### PR TITLE
Add globals as a static of application

### DIFF
--- a/lib/viking/application.js
+++ b/lib/viking/application.js
@@ -13,6 +13,12 @@ export default class Application extends View {
   static events = { 'click a[href]': 'pushState' };
   
   /**
+  * Define attributes to be passed to all views on display
+  * @static {Object,Function}
+  */ 
+  static globals = {};
+  
+  /**
   * this is constructor description.
   * @param {number} arg1 this is arg1 description.
   * @param {string[]} arg2 this is arg2 description.
@@ -40,8 +46,8 @@ export default class Application extends View {
 
   async display(view, options) {
     const oldView = this.view;
-    
-    this.view = new view(options);
+
+    this.view = new view(Object.assign({}, result(this.constructor, 'globals', this), options));
 
     await this.view.render();
 

--- a/test/applicationTest.js
+++ b/test/applicationTest.js
@@ -51,4 +51,45 @@ describe('Viking/Application', () => {
         
         const app = new MyApplication();
     });
+    
+    describe('#display', () => {
+        it('global property as object', done => {
+            class MyApplication extends Application {
+                static globals = {
+                    foo: 'bar'
+                }
+            }
+            class MyView extends View {
+                constructor (locals) {
+                    super(locals)
+                    assert.equal('bar', locals.foo)
+                    done()
+                }
+            }
+            let app = new MyApplication();
+        
+            app.display(MyView);
+        })
+        
+        it('global property as function', done => {
+            class MyApplication extends Application {
+                static globals = function (app) {
+                    return { app }
+                }
+            }
+            let app = new MyApplication();
+            
+            class MyView extends View {
+                constructor (locals) {
+                    super(locals)
+                    assert.ok(locals.app == app)
+                    done()
+                }
+            }
+        
+            app.display(MyView);
+        })
+    })
+    
+    
 });


### PR DESCRIPTION
Support applications having static global to define properties passed to each view on `display`.
```javascript
class App extends Application {
    static globals = app => {
        return { app }
    }
}
```