### PR TITLE
Saving Promises

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -665,25 +665,21 @@ export default class Record extends EventBus {
 
         let method = this.isNewRecord() ? 'post' : 'put';
         let path   = this.isNewRecord() ? result(this, 'urlRoot') : this.url();
+        // TODO: should we be setting request body here, or when request is actually sent,
+        // which can be after attributes of the record have changed
         const optionsForSync = this.optionsForSync('save', options)
         
         const sendRequest = () => {
-            const request = this.constructor.connection[method](path, optionsForSync)
-            this._saving = request
-            request.finally(() => {
-                if (request == this._saving) {
-                    this._saving = null
-                }
+            this._savingRequest = this.constructor.connection[method](path, optionsForSync)
+            this._saving = this._savingRequest.finally(() => {
+                this._saving = null
+                this._savingRequest = null
             })
             return this._saving
         }
         
         if (this._saving) {
-            return new Promise((resolve) => {
-                this._saving.then(() => {
-                    resolve(sendRequest())
-                })
-            })
+            return this._saving.then(sendRequest)
         } else {
             return sendRequest()
         }

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -665,24 +665,32 @@ export default class Record extends EventBus {
 
         let method = this.isNewRecord() ? 'post' : 'put';
         let path   = this.isNewRecord() ? result(this, 'urlRoot') : this.url();
-
-        const nextReq = () => this.constructor.connection[method](path, this.optionsForSync('save', options));
-
-        if (this._saving) {
-            this._saving.then(nextReq);
-        } else {
-            this._saving = nextReq.call();
+        const optionsForSync = this.optionsForSync('save', options)
+        
+        const sendRequest = () => {
+            const request = this.constructor.connection[method](path, optionsForSync)
+            this._saving = request
+            request.finally(() => {
+                if (request == this._saving) {
+                    this._saving = null
+                }
+            })
+            return this._saving
         }
-
-        return this._saving;
+        
+        if (this._saving) {
+            return new Promise((resolve) => {
+                this._saving.then(() => {
+                    resolve(sendRequest())
+                })
+            })
+        } else {
+            return sendRequest()
+        }
     }
     
     isSaving() {
-        if (this._saving) {
-            return !(this._saving.status == "fulfilled" || this._saving.status == "rejected");
-        }
-        
-        return false;
+        return !!this._saving
     }
     
     async reload(options = {}) {

--- a/test/recordTest.js
+++ b/test/recordTest.js
@@ -69,7 +69,7 @@ describe('Viking.Record', () => {
         assert.equal(doc.readAttribute('author'), 'Bill Shakespeare');
     });
     
-    it('isSaving', function () {
+    it('isSaving', function (done) {
         let doc = new Actor({title: 'The Tempest', author: 'Bill Shakespeare'});
         assert.equal(false, doc.isSaving());
         
@@ -78,12 +78,12 @@ describe('Viking.Record', () => {
         this.withRequest('POST', '/actors', { body: {
             actor: { title: 'The Tempest', author: 'Bill Shakespeare'  }
         }}, (xhr) => {
-            xhr.respond(201, {}, '{"id": 1, "name": { title: "The Tempest", author: "Bill Shakespeare"  }}');
+            xhr.respond(201, {}, '{"id": 1, "name": { "title": "The Tempest", "author": "Bill Shakespeare"}}');
         });
         
         promise.then(() =>
             assert.equal(doc.isSaving(), false)
-        );
+        ).then(done, done);
         
         assert.doesNotReject(promise);
     });


### PR DESCRIPTION
afterSave callbacks were firing before saves finished, so tests were added and fixes.

Solution: `save()` sets and returns a promise for that specific request vs the currently saving request