### PR TITLE
Extract resolveTarget from load for reuse

### DIFF
--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -153,15 +153,7 @@ export default class Relation extends EventBus {
             if (this._calculate) {
                 this.target = response;
             } else {
-                this.setTarget(response.map((attributes, index) => {
-                    let target = this.target.find(x => x.primaryKey() == attributes[this.klass.primaryKey])
-                    if (target) {
-                        target.setAttributesAndAssociations(attributes)
-                    } else {
-                        target = this.klass.instantiate(attributes)
-                    }
-                    return target
-                }), ...eventParameters)
+                this.setTarget(this.resolveTarget(response), ...eventParameters)
             }
             
             /**
@@ -194,6 +186,27 @@ export default class Relation extends EventBus {
         });
 
         return p;
+    }
+
+    /**
+     * Resolves an array of attribute hashes into Record instances, reusing
+     * records already in `target` when their primary key matches and
+     * instantiating new records otherwise.
+     *
+     * @instance
+     * @param  {Object[]} response An array of attribute hashes
+     * @return {Record[]}
+     */
+    resolveTarget(response) {
+        return response.map((attributes) => {
+            let target = this.target.find(x => x.primaryKey() == attributes[this.klass.primaryKey])
+            if (target) {
+                target.setAttributesAndAssociations(attributes)
+            } else {
+                target = this.klass.instantiate(attributes)
+            }
+            return target
+        })
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extracts the attribute-hash → Record reconciliation logic from `Relation#load` into a new `resolveTarget(response)` method that returns an array of Records, reusing existing target records by primary key or instantiating new ones.
- `load` now calls `this.setTarget(this.resolveTarget(response), ...eventParameters)`.
- Lets other paths (association loaders, adapter response handling, etc.) reuse the same find-or-instantiate logic without duplicating it.

## Test plan
- [ ] `npm test` — verify no regressions (pre-existing failures on `connection` base branch are unrelated: 6 failures in JSONAPIConnection/Connection tests, unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)