### PR TITLE
Extract resolveTarget from load for reuse

### DIFF
--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -153,15 +153,7 @@ export default class Relation extends EventBus {
             if (this._calculate) {
                 this.target = response;
             } else {
-                this.setTarget(response.map((attributes, index) => {
-                    let target = this.target.find(x => x.primaryKey() == attributes[this.klass.primaryKey])
-                    if (target) {
-                        target.setAttributesAndAssociations(attributes)
-                    } else {
-                        target = this.klass.instantiate(attributes)
-                    }
-                    return target
-                }), ...eventParameters)
+                this.setTarget(this.resolveTarget(response), ...eventParameters)
             }
             
             /**
@@ -194,6 +186,27 @@ export default class Relation extends EventBus {
         });
 
         return p;
+    }
+
+    /**
+     * Resolves an array of attribute hashes into Record instances, reusing
+     * records already in `target` when their primary key matches and
+     * instantiating new records otherwise.
+     *
+     * @instance
+     * @param  {Object[]} response An array of attribute hashes
+     * @return {Record[]}
+     */
+    resolveTarget(response) {
+        return response.map((attributes) => {
+            let target = this.target.find(x => x.primaryKey() == attributes[this.klass.primaryKey])
+            if (target) {
+                target.setAttributesAndAssociations(attributes)
+            } else {
+                target = this.klass.instantiate(attributes)
+            }
+            return target
+        })
     }
 
     /**


### PR DESCRIPTION
Pulls the response-to-Record resolution logic out of `Relation#load` into a `resolveTarget` method so it can be reused (e.g. by adapters that need to materialize records outside the normal load path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)