### PR TITLE
Don't set foreign key on hasAndBelongsToMany records

### DIFF
--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -95,14 +95,14 @@ export default class CollectionAssociation extends Association {
                 a[1].dispatchEvent('beforeAdd', this);
 
                 this.target.push(a[1])
-                this.setForeignKeyAttributes(a[1]);
+                this.setForeignKey(a[1]);
                 a[1].collections.add(this)
 
                 a[1].dispatchEvent('afterAdd', this)
             } else if (a[0] == 'removed') {
                 a[1].dispatchEvent('beforeRemove', this);
 
-                this.unsetForeignKeyAttributes(a[1]);
+                this.unsetForeignKey(a[1]);
                 const thisIndex = a[1].collections.delete(this);
 
                 a[1].dispatchEvent('afterRemove', this)
@@ -315,16 +315,15 @@ export default class CollectionAssociation extends Association {
         }
     }
     
-    // Points a record at this association's owner. Overridden by associations
-    // whose relationship isn't stored on the record itself.
-    setForeignKeyAttributes(record) {
+    // Points a record at this association's owner.
+    setForeignKey(record) {
         const ownerKey = this.owner.readAttribute(this.primaryKey());
         if (ownerKey) {
             record.setAttributes({ [this.foreignKey()]: ownerKey });
         }
     }
 
-    unsetForeignKeyAttributes(record) {
+    unsetForeignKey(record) {
         record.setAttributes({ [this.foreignKey()]: null });
     }
 
@@ -386,14 +385,14 @@ export default class CollectionAssociation extends Association {
                 record.dispatchEvent('beforeAdd', this);
                 
                 this.target.push(record)
-                this.setForeignKeyAttributes(record);
+                this.setForeignKey(record);
                 record.collections.add(this)
 
                 record.dispatchEvent('afterAdd', this)
             } else if (a[0] == 'removed') {
                 a[1].dispatchEvent('beforeRemove', this);
 
-                this.unsetForeignKeyAttributes(a[1]);
+                this.unsetForeignKey(a[1]);
                 const thisIndex = a[1].collections.delete(this);
                 
                 a[1].dispatchEvent('afterRemove', this)

--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -85,11 +85,7 @@ export default class CollectionAssociation extends Association {
 
     setTarget(newTarget, {dirty=true, inPlaceUpdate=false}={}) {
         const merged = this.mergeRecords(this.target, newTarget);
-        const setForeignKeyParams = this.owner.readAttribute(this.primaryKey()) ?
-            { [this.foreignKey()]: this.owner.readAttribute(this.primaryKey()) } :
-            {};
-        const unsetForeignKeyParams = { [this.foreignKey()]: null }
-        
+
         if (merged.added.length > 0) { this.dispatchEvent('beforeAdd', merged.added); }
         if (merged.removed.length > 0) { this.dispatchEvent('beforeRemove', merged.removed); }
 
@@ -97,18 +93,18 @@ export default class CollectionAssociation extends Association {
         merged.merged.forEach((a) => {
             if (a[0] === 'added') {
                 a[1].dispatchEvent('beforeAdd', this);
-                
+
                 this.target.push(a[1])
-                a[1].setAttributes(setForeignKeyParams);
+                this.setForeignKeyAttributes(a[1]);
                 a[1].collections.add(this)
-                
+
                 a[1].dispatchEvent('afterAdd', this)
             } else if (a[0] == 'removed') {
                 a[1].dispatchEvent('beforeRemove', this);
-                
-                a[1].setAttributes(unsetForeignKeyParams);
+
+                this.unsetForeignKeyAttributes(a[1]);
                 const thisIndex = a[1].collections.delete(this);
-                
+
                 a[1].dispatchEvent('afterRemove', this)
             } else {
                 let record = a[1];
@@ -319,6 +315,19 @@ export default class CollectionAssociation extends Association {
         }
     }
     
+    // Points a record at this association's owner. Overridden by associations
+    // whose relationship isn't stored on the record itself.
+    setForeignKeyAttributes(record) {
+        const ownerKey = this.owner.readAttribute(this.primaryKey());
+        if (ownerKey) {
+            record.setAttributes({ [this.foreignKey()]: ownerKey });
+        }
+    }
+
+    unsetForeignKeyAttributes(record) {
+        record.setAttributes({ [this.foreignKey()]: null });
+    }
+
     foreignType () {
         if (this.reflection.options.foreignType) {
             return this.reflection.options.foreignType;
@@ -362,11 +371,7 @@ export default class CollectionAssociation extends Association {
         }
         
         const merged = this.mergeRecords(this.target, attributes);
-        const setForeignKeyParams = this.owner.readAttribute(this.primaryKey()) ?
-            { [this.foreignKey()]: this.owner.readAttribute(this.primaryKey()) } :
-            {};
-        const unsetForeignKeyParams = { [this.foreignKey()]: null }
-        
+
         if (merged.added.length > 0) {
             merged.added = merged.added.map((r) => (r instanceof Record) ? r : this.reflection.model.instantiate(r))
             this.dispatchEvent('beforeAdd', merged.added);
@@ -381,14 +386,14 @@ export default class CollectionAssociation extends Association {
                 record.dispatchEvent('beforeAdd', this);
                 
                 this.target.push(record)
-                record.setAttributes(setForeignKeyParams);
+                this.setForeignKeyAttributes(record);
                 record.collections.add(this)
-                
+
                 record.dispatchEvent('afterAdd', this)
             } else if (a[0] == 'removed') {
                 a[1].dispatchEvent('beforeRemove', this);
-                
-                a[1].setAttributes(unsetForeignKeyParams);
+
+                this.unsetForeignKeyAttributes(a[1]);
                 const thisIndex = a[1].collections.delete(this);
                 
                 a[1].dispatchEvent('afterRemove', this)

--- a/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
+++ b/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
@@ -14,9 +14,9 @@ export default class HasAndBelongsToManyAssociation extends CollectionAssociatio
 
     // The join table holds the foreign key, not the associated record, so
     // adding or removing a record must not write one onto it.
-    setForeignKeyAttributes(record) {}
+    setForeignKey(record) {}
 
-    unsetForeignKeyAttributes(record) {}
+    unsetForeignKey(record) {}
 
     scope() {
         let klass = this.reflection.model;

--- a/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
+++ b/lib/viking/record/associations/hasAndBelongsToManyAssociation.js
@@ -12,45 +12,12 @@ export default class HasAndBelongsToManyAssociation extends CollectionAssociatio
         }
     }
 
-    setTarget(newTarget, {dirty=true, inPlaceUpdate=false}={}) {
-        const merged = this.mergeRecords(this.target, newTarget);
-        
-        if (merged.added.length > 0) { this.dispatchEvent('beforeAdd', merged.added); }
-        if (merged.removed.length > 0) { this.dispatchEvent('beforeRemove', merged.removed); }
+    // The join table holds the foreign key, not the associated record, so
+    // adding or removing a record must not write one onto it.
+    setForeignKeyAttributes(record) {}
 
-        this.target.splice(0, this.target.length)
-        merged.merged.forEach((a) => {
-            if (a[0] === 'added') {
-                a[1].dispatchEvent('beforeAdd', this);
-                
-                this.target.push(a[1])
-                a[1].collections.add(this)
-                
-                a[1].dispatchEvent('afterAdd', this)
-            } else if (a[0] == 'removed') {
-                a[1].dispatchEvent('beforeRemove', this);
-                
-                const thisIndex = a[1].collections.delete(this);
-                
-                a[1].dispatchEvent('afterRemove', this)
-            } else {
-                let record = a[1];
-                if (inPlaceUpdate) {
-                    record = a[2];
-                    record.setAttributes(a[1].attributes);
-                }
-                if (!dirty) { record.persist(); }
-                this.target.push(record)
-            }
-        });
-        this.loaded = true;
-        this.dirty = dirty;
-        
-        if (merged.added.length > 0) { this.dispatchEvent('afterAdd', merged.added); }
-        if (merged.removed.length > 0) { this.dispatchEvent('afterRemove', merged.removed); }
-    }
+    unsetForeignKeyAttributes(record) {}
 
-    
     scope() {
         let klass = this.reflection.model;
         

--- a/test/record/associations/autosaveAssociations/hasAndBelongsToManyAutosaveTest.js
+++ b/test/record/associations/autosaveAssociations/hasAndBelongsToManyAutosaveTest.js
@@ -79,6 +79,19 @@ describe('Viking.Record HasAndBelongsToManyAssociation autosave', () => {
             });
         });
 
+        it('does not send the association when only a parent attribute changes', function (done) {
+            let model = Requirement.instantiate({id: 24, phases: [{ id: 11, name: 'Tom' }]});
+
+            model.setAttribute('planet', 'Venus');
+            model.save().then(() => assert.ok(true)).then(done, done);
+
+            this.withRequest('PUT', '/requirements/24', { body: {
+                requirement: { planet: 'Venus' }
+            }}, (xhr) => {
+                xhr.respond(201, {}, '{"id": 24, "planet": "Venus"}');
+            });
+        });
+
         it('removes the relation', function (done) {
             let model = Requirement.instantiate({id: 24, phases: [{ id: 11, name: 'Tom' }]});
             let phase = model.phases.first();

--- a/test/record/associations/hasAndBelongsToManyTest.js
+++ b/test/record/associations/hasAndBelongsToManyTest.js
@@ -83,6 +83,27 @@ describe('Viking.Record::associations', () => {
                 assert.deepStrictEqual(models, parents);
                 assert.equal(this.requests.length, 0);
             });
+            
+            it('instantiating included habtm association', async function() {
+                let model = new Model({id: 13, parents: [{id: 1}, {id: 2}]});
+            
+                assert.ok(model._associations.parents.loaded);
+                assert.deepStrictEqual(
+                    model._associations.parents.target.map(x => x.attributes),
+                    [{id: 1}, {id: 2}]
+                );
+            });
+            
+            it('setAttributesAndAssociations with habtm association', async function() {
+                let model = new Model({id: 13});
+                model.setAttributesAndAssociations({parents: [{id: 1}, {id: 2}]})
+            
+                assert.ok(model._associations.parents.loaded);
+                assert.deepStrictEqual(
+                    model._associations.parents.target.map(x => x.attributes),
+                    [{id: 1}, {id: 2}]
+                );
+            });
 
         });
         


### PR DESCRIPTION
Fixes #167

## Problem

`HasAndBelongsToManyAssociation` only overrode `setTarget`, not `setAttributes`. So whenever a HABTM value was assigned as a plain array — `new Model({parents: [...]})`, `setAttributesAndAssociations`, or a server response applied after save/load — it fell through to the generic `CollectionAssociation#setAttributes`, which unconditionally writes the owner's foreign key onto each associated record.

That's correct for `hasMany`, where the foreign key is a column on the child. It's wrong for `hasAndBelongsToMany`, where the join table holds the foreign key and the associated record has no such column. The result was records polluted with a bogus attribute:

```json
{ "brokers": [{ "id": "0e39b23c...", "tim_id": "38452cd7..." }] }
```

Since that write goes through `setAttributes`, it also marked the associated records dirty, pulling them into the save payload even when nothing about them had changed.

## Fix

Extract the foreign key writes from `setTarget`/`setAttributes` into two overridable hooks on `CollectionAssociation`:

```js
setForeignKeyAttributes(record)
unsetForeignKeyAttributes(record)
```

`HasAndBelongsToManyAssociation` overrides both as no-ops. This also lets HABTM delete its copy of `setTarget`, which was a near-verbatim duplicate of the parent's that existed only to skip those same two writes — so the add/remove path is now defined in one place for both association types.

Also removes a leftover debug `console.log` in `CollectionAssociation#setAttributes`.

## Tests

Three tests covering this were already unstaged on master and are included here:

- `hasAndBelongsToManyTest.js` — "instantiating included habtm association" and "setAttributesAndAssociations with habtm association" assert the associated records keep exactly `{id: n}` with no injected foreign key. The latter failed before this change (`model_id: 13` on each record).
- `hasAndBelongsToManyAutosaveTest.js` — "does not send the association when only a parent attribute changes" covers the payload symptom.

Full suite: 719 passing, 0 failing.