### PR TITLE
Extract record matching logic into overridable methods

### DIFF
--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -24,24 +24,9 @@ export default class CollectionAssociation extends Association {
         const newToOldIndexes = newRecords.map((newRecord) => {
             const oldIndex = oldRecords.findIndex((y) => {
                 if (newRecord instanceof Record) {
-                    if (newRecord.primaryKey() && newRecord.primaryKey() === y.primaryKey()) {
-                        return true
-                    } else if (newRecord.cid === y.cid) {
-                        return true
-                    // } else if (y.isNewRecord()) {
-                    //     return isEqual(y.attributes, pick(newRecord.attributes, Object.keys(y.attributes)))
-                    } else {
-                        return false;
-                    }
+                    return this.isMatchingRecord(y, newRecord)
                 } else {
-                    const newRecordPK = newRecord[this.reflection.model.primaryKey];
-                    if (newRecordPK && newRecordPK === y.primaryKey()) {
-                        return true
-                    } else if (y.isNewRecord()) {
-                        return isEqual(y.attributes, pick(newRecord, Object.keys(y.attributes)))
-                    } else {
-                        return false;
-                    }
+                    return this.isAttributesForRecord(y, newRecord)
                 }
             });
             return oldIndex
@@ -81,6 +66,27 @@ export default class CollectionAssociation extends Association {
             common: commonRecords,
             removed: removedRecords
         };
+    }
+    
+    isMatchingRecord(recordA, recordB) {
+        if (recordB.primaryKey() && recordB.primaryKey() === recordA.primaryKey()) {
+            return true
+        } else if (recordA.cid === recordB.cid) {
+            return true
+        // } else if (recordB.isNewRecord()) {
+        //     return isEqual(recordB.attributes, pick(recordA.attributes, Object.keys(recordB.attributes)))
+        }
+        return false;
+    }
+    
+    isAttributesForRecord(record, attributes) {
+        const key = attributes[this.reflection.model.primaryKey];
+        if (key && key === record.primaryKey()) {
+            return true
+        } else if (record.isNewRecord()) {
+            return isEqual(record.attributes, pick(attributes, Object.keys(record.attributes)))
+        }
+        return false;
     }
 
     setTarget(newTarget, {dirty=true, inPlaceUpdate=false}={}) {


### PR DESCRIPTION
## Summary

Pulls the inline record-comparison branches out of `CollectionAssociation#mergeRecords` into two named methods:

- `isMatchingRecord(recordA, recordB)` — compares two `Record` instances
- `isAttributesForRecord(record, attributes)` — compares a `Record` against a plain attributes hash

The motivation is extensibility: applications can now override either method to control how a collection association decides that an incoming record or attributes hash corresponds to an existing record in the target, rather than being stuck with the built-in primary-key/cid/attribute-subset rules.

## Behavior

No behavior change — the extracted methods preserve the original comparison order and short-circuiting exactly, including the commented-out new-record branch in `isMatchingRecord`.

## Testing

`npm test` — 722 passing, 0 failing (unchanged from `master`).