### PR TITLE
Dispatch record:afterSync events to record's collections

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -803,7 +803,16 @@ export default class Record extends EventBus {
              * @param {Object} options - Options for the sync operation
              */
             this.dispatchEvent('afterSync', changes, options);
-            
+
+            /**
+             * Fired on each collection containing this record after the record
+             * has been synced with the server.
+             * @event Relation#record:afterSync
+             * @param {Record} record - The record that was synced
+             * @param {Object} savedChanges - The changes that were synced
+             */
+            this.collections.forEach(c => c.dispatchEvent('record:afterSync', this, changes));
+
             each(changes, (key, value) => {
                 /**
                  * Fired after a specific attribute has been synced with the server
@@ -812,8 +821,18 @@ export default class Record extends EventBus {
                  * @param {*} newValue - The new value of the attribute
                  */
                 this.dispatchEvent('afterSync:'+key, value[0], value[1]);
+
+                /**
+                 * Fired on each collection containing this record after a
+                 * specific attribute on the record has been synced.
+                 * @event Relation#record:afterSync:{attribute}
+                 * @param {Record} record - The record that was synced
+                 * @param {*} oldValue - The previous value of the attribute
+                 * @param {*} newValue - The new value of the attribute
+                 */
+                this.collections.forEach(c => c.dispatchEvent('record:afterSync:' + key, this, value[0], value[1]));
             });
-            
+
             return true;
         }
 

--- a/test/record/relation/eventTest.js
+++ b/test/record/relation/eventTest.js
@@ -50,6 +50,112 @@ describe('Viking.Relation', () => {
             });
         })
 
+        it('record:afterSync', function (done) {
+            const relation = NamedModel.where({parent_id: 11})
+
+            relation.load().then(() => {
+                const record = relation.target[0]
+
+                relation.addEventListener('record:afterSync', (r, changes) => {
+                    try {
+                        assert.strictEqual(r, record);
+                        assert.deepEqual(changes, {name: ['foo', 'bar']});
+                    } catch (e) { done(e); }
+                    done();
+                });
+
+                record.setAttributes({name: 'bar'});
+                record.save();
+
+                this.withRequest('PUT', '/named_models/1', { body: {named_model: {name: 'bar'}} }, (xhr) => {
+                    xhr.respond(200, {}, '{"id": 1, "name": "bar"}');
+                });
+            });
+
+            this.withRequest('GET', '/named_models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1, "name": "foo"}]');
+            });
+        })
+
+        it('record:afterSync:[attribute]', function (done) {
+            const relation = NamedModel.where({parent_id: 11})
+
+            relation.load().then(() => {
+                const record = relation.target[0]
+
+                relation.addEventListener('record:afterSync:name', (r, oldValue, newValue) => {
+                    try {
+                        assert.strictEqual(r, record);
+                        assert.equal(oldValue, 'foo');
+                        assert.equal(newValue, 'bar');
+                    } catch (e) { done(e); }
+                    done();
+                });
+
+                record.setAttributes({name: 'bar'});
+                record.save();
+
+                this.withRequest('PUT', '/named_models/1', { body: {named_model: {name: 'bar'}} }, (xhr) => {
+                    xhr.respond(200, {}, '{"id": 1, "name": "bar"}');
+                });
+            });
+
+            this.withRequest('GET', '/named_models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1, "name": "foo"}]');
+            });
+        })
+
+        it('record:afterSync:[attribute] on reload', function (done) {
+            const relation = NamedModel.where({parent_id: 11})
+
+            relation.load().then(() => {
+                const record = relation.target[0]
+
+                relation.addEventListener('record:afterSync:name', (r, oldValue, newValue) => {
+                    try {
+                        assert.strictEqual(r, record);
+                        assert.equal(oldValue, 'foo');
+                        assert.equal(newValue, 'baz');
+                    } catch (e) { done(e); }
+                    done();
+                });
+
+                record.reload();
+
+                this.withRequest('GET', '/named_models/1', {}, (xhr) => {
+                    xhr.respond(200, {}, '{"id": 1, "name": "baz"}');
+                });
+            });
+
+            this.withRequest('GET', '/named_models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1, "name": "foo"}]');
+            });
+        })
+
+        it('record:afterSync not fired after record removed from collection', function (done) {
+            const relation = NamedModel.where({parent_id: 11})
+
+            relation.load().then(() => {
+                const record = relation.target[0]
+                relation.remove(record)
+
+                relation.addEventListener('record:afterSync', () => {
+                    done(new Error('record:afterSync fired after removal'));
+                });
+
+                record.setAttributes({name: 'bar'});
+                record.save().then(() => done());
+
+                this.withRequest('PUT', '/named_models/1', { body: {named_model: {name: 'bar'}} }, (xhr) => {
+                    xhr.respond(200, {}, '{"id": 1, "name": "bar"}');
+                });
+            });
+
+            this.withRequest('GET', '/named_models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1, "name": "foo"}]');
+            });
+        })
+
         it('record:changed not fired after record removed from collection', function (done) {
             const relation = NamedModel.where({parent_id: 11})
 


### PR DESCRIPTION
## What

Mirrors `record:changed` / `record:changed:{attribute}` (#163) for the sync side. After a record syncs with the server, `Record` now also dispatches on each `Relation`/`CollectionAssociation` in `record.collections`:

- `record:afterSync` — `(record, savedChanges)`
- `record:afterSync:{attribute}` — `(record, oldValue, newValue)`

Same call sites as the existing per-record `afterSync` / `afterSync:{attribute}`, so it covers `save()` and `reload()` alike.

## Why

A collection can already hear that one of its records changed, but `record:changed:{attribute}` fires at **assignment** time. A consumer that has to react to the *persisted* value — anything reading back state the server derives from the write — sees the event before the request has gone out.

The concrete case: a spreadsheet cell showing a server-calculated value (a formula over sibling records). It watches the collection so one listener covers every dependency, and on a change it refetches its own record. With only `record:changed:value` available, the refetch races the dependency's save — measured order was `GET` of the calculated record, *then* `PUT` of the edited one — and nothing fires again afterwards, so the cell keeps a stale value.

## What this avoids

Without it, every consumer that wants the synced value has to branch on dirtiness and attach a one-shot listener to whichever record changed:

```js
collection.addEventListener('record:changed:value', record => {
    if (!dependsOn(record.key)) return
    // fires on assignment, so wait out this record's own save before reading
    // back what the server derived from it
    if (record.hasChanged('value')) {
        record.addEventListener('afterSync:value', refresh, { once: true })
    } else {
        refresh()
    }
})
```

That is per-record bookkeeping for something the collection is already positioned to observe, and it has to be repeated by every such consumer. With this change the same logic is:

```js
collection.addEventListener('record:afterSync:value', record => {
    if (dependsOn(record.key)) refresh()
})
```

## Test plan

- [x] `npm test` — 867 passing, 1 pending
- [x] Added to `test/record/relation/eventTest.js`, alongside the `record:changed` cases: `record:afterSync`, `record:afterSync:[attribute]`, the same on `reload()`, and not-fired-after-removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)