### PR TITLE
Set the polymorphic foreign type alongside the foreign key

### DIFF
--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -318,16 +318,24 @@ export default class CollectionAssociation extends Association {
         }
     }
     
-    // Points a record at this association's owner.
+    // Points a record at this association's owner. Polymorphic (`as`)
+    // associations also carry the owner's type, so the record can identify
+    // its owner the same way the association's scope() looks it up.
     setForeignKey(record) {
         const ownerKey = this.owner.readAttribute(this.primaryKey());
         if (ownerKey) {
             record.setAttributes({ [this.foreignKey()]: ownerKey });
         }
+        if (this.reflection.options.as && this.owner.modelName) {
+            record.setAttributes({ [this.foreignType()]: this.owner.modelName.name });
+        }
     }
 
     unsetForeignKey(record) {
         record.setAttributes({ [this.foreignKey()]: null });
+        if (this.reflection.options.as) {
+            record.setAttributes({ [this.foreignType()]: null });
+        }
     }
 
     foreignType () {

--- a/test/record/associations/hasManyTest.js
+++ b/test/record/associations/hasManyTest.js
@@ -419,12 +419,25 @@ describe('Viking.Record::associations', () => {
                 model.parents = [parent];
 
                 assert.equal(parent.readAttribute('offspring_id'), 24);
+                assert.equal(parent.readAttribute('offspring_type'), 'Child');
                 assert.ok(model._associations.parents.loaded);
                 assert.strictEqual(model._associations.parents.target[0], parent);
                 model.parents.toArray().then(models => {
                     assert.strictEqual(models[0], parent);
                 }).then(done, done);
                 assert.equal(this.requests.length, 0);
+            });
+        });
+
+        describe('removing from the association', () => {
+            it('unsets the foreign key and type', function() {
+                let model = new Child({id: 24});
+                let parent = new Parent({id: 13});
+                model.parents = [parent];
+                model.parents = [];
+
+                assert.equal(parent.readAttribute('offspring_id'), null);
+                assert.equal(parent.readAttribute('offspring_type'), null);
             });
         });
     });


### PR DESCRIPTION
## What

`CollectionAssociation#setForeignKey` points added records at the association's owner via the foreign key only. For polymorphic (`as:`) associations, the type column is never set — and `unsetForeignKey` nulls only the key, leaving a stale type on removed records.

This means a record built client-side and added to e.g. `hasMany(Parent, {as: 'subject'})` can't be looked up by the same `subject_type`/`subject_id` pair that the association's own `scope()` queries by, until a server round-trip happens to backfill it.

## How

- `setForeignKey` also sets the foreign type from the owner's model name when the reflection has `as:` (mirroring the `scope()` where-clause and `hasOneAssociation`'s existing behavior)
- `unsetForeignKey` nulls the type together with the key
- HABTM is unaffected — it already overrides both as no-ops

Both `setTarget` and `setAttributes` route through these helpers, so every add/remove path is covered.

## Testing

Extended the `hasMany(Parent, {as: NAME})` assign test to assert the type, and added a removal test asserting key and type are both nulled. Full suite: 868 passing.

Found via intel-rails, where a Trait added to `tim.traits` (`as: 'subject'`) carried `subject_type: null` client-side, and a displaced trait kept a stale `subject_type` after losing its `subject_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)