### PR TITLE
Rename Relation#includes to eagerLoad and add array methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Major Changes:
 
+ - Renamed `Relation#includes` / `Record::includes` to `Relation#eagerLoad` /
+   `Record::eagerLoad` (and `Relation#setIncludes` to `Relation#setEagerLoads`)
+
 ## 0.9.0 (May 8th, 2016)
 
 Major Changes:

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -264,11 +264,11 @@ export default class Record extends EventBus {
     
     /**
      * Eager-loads specified associations with records of this model
-     * @param {...string} args - The associations to include
-     * @returns {Relation} A relation with the includes operation
+     * @param {...string} args - The associations to eager load
+     * @returns {Relation} A relation with the eager load operation
      */
-    static includes(...args) {
-        return this.all().includes(...args);
+    static eagerLoad(...args) {
+        return this.all().eagerLoad(...args);
     }
     
     /**

--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -149,53 +149,49 @@ export default class CollectionAssociation extends Association {
         }
     }
     
-    map(...args) {
-        const load = this.load();
-
-        if (load instanceof Promise) {
-            return load.then((records) => records.map(...args));
-        } else {
-            return load.map(...args);
-        }
+    async map(...args) {
+        const records = await this.load();
+        return records.map(...args);
     }
-    
-    filter(...args) {
-        let load = this.load();
 
-        if (load instanceof Promise) {
-            return load.then((records) => records.filter(...args));
-        } else {
-            return load.filter(...args);
-        }
+    async filter(...args) {
+        const records = await this.load();
+        return records.filter(...args);
     }
-    
-    find(...args) {
-        let load = this.load()
-        if(load instanceof Promise) {
-            return load.then(records => records.find(...args));
-        } else {
-            return load.find(...args);
-        }
-    }
-    
-    forEach(...args) {
-        let load = this.load();
 
-        if (load instanceof Promise) {
-            return load.then((records) => records.forEach(...args));
-        } else {
-            return load.forEach(...args);
-        }
+    async find(...args) {
+        const records = await this.load();
+        return records.find(...args);
     }
-    
-    length () {
-        let load = this.load();
 
-        if (load instanceof Promise) {
-            return load.then((records) => records.length);
-        } else {
-            return load.length;
-        }
+    async includes(...args) {
+        const records = await this.load();
+        return records.includes(...args);
+    }
+
+    async some(...args) {
+        const records = await this.load();
+        return records.some(...args);
+    }
+
+    async every(...args) {
+        const records = await this.load();
+        return records.every(...args);
+    }
+
+    async reduce(...args) {
+        const records = await this.load();
+        return records.reduce(...args);
+    }
+
+    async forEach(...args) {
+        const records = await this.load();
+        return records.forEach(...args);
+    }
+
+    async length () {
+        const records = await this.load();
+        return records.length;
     }
     
     async add (record, options) {

--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -432,8 +432,8 @@ export default class Relation extends EventBus {
         return this.spawn().setOffset(number);
     }
     
-    includes(...args) {
-        return this.spawn().setIncludes(...args);
+    eagerLoad(...args) {
+        return this.spawn().setEagerLoads(...args);
     }
     
     distinct (...args) {
@@ -482,15 +482,15 @@ export default class Relation extends EventBus {
         return this;
     }
 
-    setIncludes(...args) {
+    setEagerLoads(...args) {
         if (args.length == 1 && Array.isArray(args[0])) {
             this._include = this._include.concat(args[0]);
         } else {
             this._include = this._include.concat(args);
         }
         this.loaded = false;
-        this.dispatchEvent('changed', 'order', args)
-        this.dispatchEvent('changed:order', args)
+        this.dispatchEvent('changed', 'eagerload', args)
+        this.dispatchEvent('changed:eagerload', args)
         return this;
     }
     

--- a/lib/viking/record/relation.js
+++ b/lib/viking/record/relation.js
@@ -341,6 +341,26 @@ export default class Relation extends EventBus {
         return this.target.filter(callback, thisArg);
     }
 
+    async includes(...args) {
+        await this.load()
+        return this.target.includes(...args);
+    }
+
+    async some(...args) {
+        await this.load()
+        return this.target.some(...args);
+    }
+
+    async every(...args) {
+        await this.load()
+        return this.target.every(...args);
+    }
+
+    async reduce(...args) {
+        await this.load()
+        return this.target.reduce(...args);
+    }
+
     // defaultOrder(): IOrder
     defaultOrder() {
         return { [this.klass.primaryKey]: 'desc' };

--- a/test/record/associations/belongsToTest.js
+++ b/test/record/associations/belongsToTest.js
@@ -126,7 +126,7 @@ describe('Viking.Record::associations', () => {
         
         describe('include', () => {
             it('instantiating null', function(done) {
-                Model.includes('parent').find(24).then(model => {
+                Model.eagerLoad('parent').find(24).then(model => {
                     assert.strictEqual(model.parent, null);
                 }).then(done, done);
             

--- a/test/record/associations/collectionAssociation/arrayMethodsTest.js
+++ b/test/record/associations/collectionAssociation/arrayMethodsTest.js
@@ -1,0 +1,97 @@
+import assert from 'assert';
+import VikingRecord from 'viking/record';
+import { hasMany } from 'viking/record/associations';
+
+describe('Viking.Record::associations', () => {
+    describe('hasMany(Parent)', () => {
+        class Parent extends VikingRecord { }
+        class Model extends VikingRecord {
+            static associations = [hasMany(Parent)];
+        }
+
+        describe('array methods', () => {
+            it("forEach iterates over the association", function(done) {
+                let model = new Model({id: 24});
+                let loaded_parents = [];
+
+                model.parents.forEach((p) => { loaded_parents.push(p) }).then(() => {
+                    assert.equal(loaded_parents.length, 2);
+                    assert.ok(loaded_parents[0] instanceof Parent);
+                    assert.equal(loaded_parents[0].readAttribute('id'), 2);
+                    assert.equal(loaded_parents[0].readAttribute('name'), 'Viking A');
+
+                    assert.ok(loaded_parents[1] instanceof Parent);
+                    assert.equal(loaded_parents[1].readAttribute('id'), 3);
+                    assert.equal(loaded_parents[1].readAttribute('name'), 'Viking B');
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+
+            it("map maps over the association", function(done) {
+                let model = new Model({id: 24});
+
+                model.parents.map((p) => p.readAttribute('id')).then((ids) => {
+                    assert.deepEqual(ids, [2,3]);
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+
+            it("includes checks membership of the association", function(done) {
+                let model = new Model({id: 24});
+
+                model.parents.load().then(async (parents) => {
+                    assert.ok(await model.parents.includes(parents[0]));
+                    assert.ok(!(await model.parents.includes(new Parent({id: 99}))));
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+
+            it("some tests if any record in the association matches", function(done) {
+                let model = new Model({id: 24});
+
+                model.parents.some((p) => p.readAttribute('id') === 3).then(async (result) => {
+                    assert.strictEqual(result, true);
+                    assert.strictEqual(await model.parents.some((p) => p.readAttribute('id') === 99), false);
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+
+            it("every tests if all records in the association match", function(done) {
+                let model = new Model({id: 24});
+
+                model.parents.every((p) => p.readAttribute('id') > 0).then(async (result) => {
+                    assert.strictEqual(result, true);
+                    assert.strictEqual(await model.parents.every((p) => p.readAttribute('id') > 2), false);
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+
+            it("reduce reduces the records in the association", function(done) {
+                let model = new Model({id: 24});
+
+                model.parents.reduce((acc, p) => acc + p.readAttribute('id'), 0).then((result) => {
+                    assert.equal(result, 5);
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+        });
+    });
+});

--- a/test/record/associations/hasManyTest.js
+++ b/test/record/associations/hasManyTest.js
@@ -100,38 +100,6 @@ describe('Viking.Record::associations', () => {
             assert.deepEqual([parent.cid, parent2.cid], model.parents.target.map(x => x.cid))
         })
 
-        it("forEach iterates over the association", function(done) {
-            let model = new Model({id: 24});
-            let loaded_parents = [];
-
-            model.parents.forEach((p) => { loaded_parents.push(p) }).then(() => {
-                assert.equal(loaded_parents.length, 2);
-                assert.ok(loaded_parents[0] instanceof Parent);
-                assert.equal(loaded_parents[0].readAttribute('id'), 2);
-                assert.equal(loaded_parents[0].readAttribute('name'), 'Viking A');
-
-                assert.ok(loaded_parents[1] instanceof Parent);
-                assert.equal(loaded_parents[1].readAttribute('id'), 3);
-                assert.equal(loaded_parents[1].readAttribute('name'), 'Viking B');
-            }).then(done, done);
-
-            this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
-                xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
-            });
-        });
-
-        it("map maps over the association", function(done) {
-            let model = new Model({id: 24});
-
-            model.parents.map((p) => p.readAttribute('id')).then((ids) => {
-                assert.deepEqual(ids, [2,3]);
-            }).then(done, done);
-
-            this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
-                xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
-            });
-        });
-
         describe('assigning the association', () => {
             it('to a model with an id', async function() {
                 let model = new Model({id: 13});

--- a/test/record/relation/arrayMethodsTest.js
+++ b/test/record/relation/arrayMethodsTest.js
@@ -1,0 +1,60 @@
+import assert from 'assert';
+import VikingRecord from 'viking/record';
+
+describe('Viking.Relation', () => {
+
+    class Model extends VikingRecord {}
+
+    describe('array methods', () => {
+        it('includes checks membership of the relation', function (done) {
+            const relation = Model.where({parent_id: 11})
+
+            relation.load().then(async (records) => {
+                assert.strictEqual(await relation.includes(records[0]), true);
+                assert.strictEqual(await relation.includes(new Model({id: 99})), false);
+            }).then(done, done);
+
+            this.withRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1}, {"id": 2}]');
+            });
+        })
+
+        it('some tests if any record matches', function (done) {
+            const relation = Model.where({parent_id: 11})
+
+            relation.some((r) => r.readAttribute('id') === 2).then(async (result) => {
+                assert.strictEqual(result, true);
+                assert.strictEqual(await relation.some((r) => r.readAttribute('id') === 99), false);
+            }).then(done, done);
+
+            this.withRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1}, {"id": 2}]');
+            });
+        })
+
+        it('every tests if all records match', function (done) {
+            const relation = Model.where({parent_id: 11})
+
+            relation.every((r) => r.readAttribute('id') > 0).then(async (result) => {
+                assert.strictEqual(result, true);
+                assert.strictEqual(await relation.every((r) => r.readAttribute('id') > 1), false);
+            }).then(done, done);
+
+            this.withRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1}, {"id": 2}]');
+            });
+        })
+
+        it('reduce reduces the records', function (done) {
+            const relation = Model.where({parent_id: 11})
+
+            relation.reduce((acc, r) => acc + r.readAttribute('id'), 0).then((result) => {
+                assert.equal(result, 3);
+            }).then(done, done);
+
+            this.withRequest('GET', '/models', { params: { where: {parent_id: 11}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1}, {"id": 2}]');
+            });
+        })
+    })
+})

--- a/test/record/relationTest.js
+++ b/test/record/relationTest.js
@@ -155,6 +155,17 @@ describe('Viking.Relation', () => {
 
                 relation.setDistinct();
             })
+
+            it('changed:eagerload', function (done) {
+                const relation = Model.where({parent_id: 11})
+
+                relation.addEventListener('changed:eagerload', (newValue) => {
+                    assert.deepEqual(newValue, ['parent']);
+                    done()
+                });
+
+                relation.setEagerLoads('parent');
+            })
         })
 
     })


### PR DESCRIPTION
### Summary

Frees up `includes` from its Rails-style eager-loading meaning so that Relation and CollectionAssociation can use it for JavaScript's `Array.prototype.includes` membership semantics, and rounds out the read-only array API on both classes.

Breaking Changes

- `Relation#includes(...)` → `Relation#eagerLoad(...)`
- `Relation#setIncludes(...)` → `Relation#setEagerLoads(...)`
- `Record.includes(...)` (static) → `Record.eagerLoad(...)`
- `setEagerLoads` now dispatches `changed` / `changed:eagerload` events (it previously dispatched changed:order by mistake)

The internal `_include` field and the `include` query param sent to the server are unchanged.

### New Array Methods

Both Relation and CollectionAssociation now support `includes`, `some`, `every`, and `reduce`, proxying to the loaded records the same way map/filter do:

```js
await model.parents.includes(parent)  // membership check
await Model.where({...}).some(r => r.readAttribute('admin'))
```

Both classes now expose the same read-only array surface: `map`, `filter`, `forEach`, `find*`, `includes`, `some`, `every`, `reduce`, `first`, `last`, `length`.

* `Relation#find(id)` retains its find-by-id semantics; `CollectionAssociation#find(callback)` is the array method.

### Cleanup

- `CollectionAssociation`'s array proxies converted to `async`/`await`, matching `Relation`'s style — the `load() instanceof Promise` branching was dead code since `load()` is `async` and always returns a `Promise`
- Array method tests moved into dedicated files: `test/record/relation/arrayMethodsTest.js` and `test/record/associations/collectionAssociation/arrayMethodsTest.js`, with new coverage for `changed:eagerload` and all the new methods
