### PR TITLE
Thenable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Major Changes:
  - Added `Record#toJSON` and `Record#[Symbol.toStringTag]`;
    `JSON.stringify(record)` emits a copy of the record's attributes instead
    of dumping internal state, and records log as `[object ModelName]`
+ - Collection associations are now thenable: `await model.parents` loads the
+   association and resolves to the records, mirroring `await model.parent`
+   on singular associations. Deep chaining (`model.parent.children.where(…)`)
+   still works — the association getter proxy shields chained associations
+   from promise assimilation. Note an association returned from an async
+   function or passed through a Promise resolves to its records
 
 ## 0.9.0 (May 8th, 2016)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,5 +110,113 @@ domReady(function(){
 })
 ```
 
+# Quickstart: Querying Records
+
+Records are fetched from your server through a connection. Point your base
+record class at an adapter once, and every model inherits it:
+
+```js
+import Record from 'viking/record';
+import StandardAPIConnection from 'viking/record/adapters/standard-api-connection';
+
+Record.connection = new StandardAPIConnection('https://api.example.com');
+```
+
+## Finding Records
+
+```js
+const cog = await Cog.find(42);        // by primary key
+const first = await Cog.first();
+const last = await Cog.last();
+const all = await Cog.all().load();    // every record, as an array
+```
+
+## Scoping with `where`
+
+`where` returns a [Relation](/relation.html) — a lazy, chainable scope.
+Nothing hits the server until the relation is loaded:
+
+```js
+Cog.where({status: 'active'})                     // equality
+Cog.where({price: {gt: 100}})                     // operators on a column
+Cog.where({status: 'active'}).where({price: {gt: 100}})  // additive
+```
+
+Refine a relation with `order`, `limit`, `offset`, `distinct`, and `groupBy`:
+
+```js
+const cogs = await Cog.where({status: 'active'})
+    .order({price: 'desc'})
+    .limit(10)
+    .load();
+```
+
+`load()` sends one request and caches the result; `reload()` fetches again.
+
+## Iterating
+
+Relations and collection associations implement the iterator protocols:
+
+```js
+for await (const cog of Cog.where({status: 'active'})) { ... }  // loads on demand
+const cogs = await Array.fromAsync(relation);                   // detached array
+
+// Once loaded, sync iteration works too:
+[...relation]
+Array.from(relation)
+```
+
+They also proxy the familiar array methods, loading on demand — `forEach`,
+`map`, `filter`, `find`, `includes`, `some`, `every`, and `reduce`:
+
+```js
+const names = await Cog.where({status: 'active'}).map((c) => c.name);
+const anyPricey = await relation.some((c) => c.price > 100);
+```
+
+## Aggregates
+
+`count` and `sum` are calculated by the server — no records are loaded:
+
+```js
+const total = await Cog.count();
+const value = await Cog.where({status: 'active'}).sum('price');
+```
+
+## Querying Associations
+
+Collection associations are scopes too — chain them like relations:
+
+```js
+const factory = await Factory.find(1);
+
+await factory.cogs;                            // load & resolve the records
+await factory.cogs.where({status: 'active'}).load();  // narrowed, separate query
+```
+
+Associations chain through unloaded records — each step loads what it
+needs:
+
+```js
+const activeCogs = await factory.region.factories.where({active: true}).map((f) => f.name);
+```
+
+Use `eagerLoad` to fetch associations alongside the records in one request:
+
+```js
+const cogs = await Cog.eagerLoad('factory').where({status: 'active'}).load();
+cogs[0].factory;   // already loaded, no request
+```
+
+## Serializing
+
+Records, relations, and associations all serialize cleanly:
+
+```js
+JSON.stringify(cog)              // the record's attributes
+JSON.stringify(loadedRelation)   // array of record attributes (throws if unloaded)
+await relation.asyncToJSON()     // loads on demand, resolves to the same output
+```
+
 
 

--- a/lib/viking/record/associations/collectionAssociation.js
+++ b/lib/viking/record/associations/collectionAssociation.js
@@ -200,6 +200,24 @@ export default class CollectionAssociation extends Association {
         return records.length;
     }
 
+    /**
+     * Makes the association a thenable, so `await model.parents` loads the
+     * association and resolves to the records — mirroring how singular
+     * associations resolve via `await model.parent`.
+     *
+     * Note this means the association is unwrapped to its records by any
+     * `await` or Promise context (e.g. returning it from an async function
+     * resolves the caller with the records, not the association). The
+     * association remains accessible via the record's getter.
+     *
+     * @param {Function} [resolve] Called with the loaded records
+     * @param {Function} [reject] Called if the load fails
+     * @return {Promise<Record[]>}
+     */
+    then(resolve, reject) {
+        return this.load().then(resolve, reject);
+    }
+
     async *[Symbol.asyncIterator]() {
         yield* await this.load();
     }

--- a/lib/viking/record/reflections/helpers.js
+++ b/lib/viking/record/reflections/helpers.js
@@ -1,5 +1,26 @@
 const isProxy = Symbol("isProxy")
+const shielded = Symbol("shielded")
 function wrappingFunction () { }
+
+// Promise resolution assimilates any thenable returned from a `then`
+// callback. Chained values that are thenable but not real Promises (e.g. a
+// thenable CollectionAssociation) must travel the proxy chain intact, so
+// they are wrapped in a non-thenable carrier and unwrapped where the chain
+// consumes them. Real Promises (async method return values) still
+// assimilate so chaining past them resolves their values.
+function shield(value) {
+    if (value && typeof value.then === 'function' && !(value instanceof Promise)) {
+        return {[shielded]: value};
+    }
+    return value;
+}
+
+function unshield(value) {
+    if (value && typeof value === 'object' && shielded in value) {
+        return value[shielded];
+    }
+    return value;
+}
 
 export function neverEndingProxy(target) {
     return new Proxy(wrappingFunction, {
@@ -7,27 +28,32 @@ export function neverEndingProxy(target) {
             if (prop === isProxy) { return target; }
 
             if ( prop === 'then' || prop === 'catch') {
-                return target[prop].bind(target);
+                // Terminal await: unshielding inside `then` lets a shielded
+                // thenable assimilate, so `await model.parent.children`
+                // loads and resolves to the records.
+                const resolved = target.then(unshield);
+                return resolved[prop].bind(resolved);
             } else {
                 return neverEndingProxy(target.then(t => {
+                    t = unshield(t);
                     let value = t[prop]
                     if (typeof value === 'function') {
                         let proxyPromise = value[isProxy];
                         if (proxyPromise) {
                             return proxyPromise.then ( (r) => {
-                                return typeof r === 'function' ? r.bind(t) : r
+                                return shield(typeof r === 'function' ? r.bind(t) : r)
                             });
                         } else {
                             return value.bind(t);
                         }
                     } else {
-                        return value;
+                        return shield(value);
                     }
                 }));
             }
         },
         apply: (fn, thisArg, args) => {
-            return neverEndingProxy(target.then((t) => t(...args)));
+            return neverEndingProxy(target.then((t) => shield(unshield(t)(...args))));
         }
     });
 }

--- a/test/record/associations/belongsToTest.js
+++ b/test/record/associations/belongsToTest.js
@@ -80,6 +80,28 @@ describe('Viking.Record::associations', () => {
             );
         });
 
+        it("resolves a chained collection association when awaited", async function() {
+            class A extends VikingRecord { }
+            class B extends VikingRecord {
+                static associations = [hasMany(A)];
+            }
+            class C extends VikingRecord {
+                static associations = [belongsTo(B)];
+            }
+
+            this.onRequest('GET', '/bs', { params: {where: {id: 2}, order: {id: 'desc'}, limit: 1} }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 5, "name": "B"}]');
+            });
+            this.onRequest('GET', '/as', { params: {where: {b_id: 5}, order: {id: 'desc'} } }, (xhr) => {
+                xhr.respond(200, {}, '[{"id": 1, "name": "A Up"}]');
+            });
+
+            let model = new C({id: 3, b_id: 2})
+
+            const as = await model.b.as;
+            assert.deepEqual(as.map((x) => x.readAttribute('id')), [1]);
+        });
+
         it("doesn't send query if not foriegnKey present", async function() {
             let model = new Model();
             

--- a/test/record/associations/collectionAssociation/arrayMethodsTest.js
+++ b/test/record/associations/collectionAssociation/arrayMethodsTest.js
@@ -176,6 +176,20 @@ describe('Viking.Record::associations', () => {
                 });
             });
 
+            it("is thenable: awaiting resolves to the records", function(done) {
+                let model = new Model({id: 24});
+
+                model.parents.then((records) => {
+                    assert.deepEqual(records.map(p => p.readAttribute('id')), [2, 3]);
+                    // the association handle is untouched and still chainable
+                    assert.equal(typeof model.parents.where, 'function');
+                }).then(done, done);
+
+                this.withRequest('GET', '/parents', { params: {where: {model_id: 24}, order: {id: 'desc'}} }, (xhr) => {
+                    xhr.respond(200, {}, '[{"id": 2, "name": "Viking A"},{"id": 3, "name": "Viking B"}]');
+                });
+            });
+
             it("has a toStringTag", function() {
                 let model = new Model({id: 24});
 

--- a/test/testHelper.js
+++ b/test/testHelper.js
@@ -133,6 +133,7 @@ after(function () {
 
 beforeEach(function () {
     this.requests = [];
+    this.requestCallbacks = [];
 });
 
 global.createElement = (tag, content) => {


### PR DESCRIPTION
Collection associations are now thenable: `await model.parents` loads the
association and resolves to the records, mirroring how singular
associations already resolve via `await model.parent`. Deep chaining
(`model.parent.children.where(…)`) keeps working — `neverEndingProxy` now
shields chained associations from promise assimilation.

Follows #173/#174 (eagerLoad rename, array methods, iterator protocols,
serialization).

## Thenable associations

```js
const units = await building.units;       // loads and resolves to the records
building.units.then(units => render(units));

// the association handle is untouched — still chainable afterwards:
building.units.where({vacant: true})
```

Precedent: Knex, Mongoose, and Prisma queries are all thenables —
deliberate `await` = deliberate load.

## The assimilation problem (and fix)

Promise resolution assimilates any thenable returned from a `then()`
callback. The association getter proxy (`neverEndingProxy`) passes chained
values through exactly that path, so a naive thenable broke deep chaining:
`model.b.as.where({x: 2})` unwrapped `as` mid-chain, fired an **unscoped**
load, and handed `.where()` an array instead of the association.

The proxy now:

- **shields** thenable non-`Promise` values (associations) in a
  non-thenable carrier when passing them along the chain
- **unshields** them when the next link accesses a property or calls a
  method — chaining stays lazy and correctly scoped
- **unshields inside a `then()` at a terminal await**, deliberately letting
  the association assimilate — so `await model.b.as` loads and resolves to
  the records
- leaves real `Promise`s (async method results like `.map()`) exempt, so
  chaining past them behaves exactly as before

## Caveat

A thenable is unwrapped by *any* promise context: returning an association
from an `async` function, `Promise.resolve(assoc)`, or `Promise.all([...])`
resolves to the **records**, not the association. The association is always
re-derivable from its record (`model.parents`), and `Relation` is
deliberately **not** thenable so scopes survive a
chainability intact.

## Test harness fix

`beforeEach` reset `this.requests` but never `this.requestCallbacks`, so a
single unconsumed `onRequest` stub leaked into ev
flipped xhr registration onto an async path, breaking synchronous
`withRequest` lookups — one real failure cascaded
Callbacks are now reset per test.