### PR TITLE
Reject XHR transport failures with Errors instead of ProgressEvents

### DIFF
--- a/lib/viking/errors.js
+++ b/lib/viking/errors.js
@@ -1,166 +1,79 @@
-export class ArgumentError extends Error {
-
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.ArgumentError';
-        this.message = message;
-    }
-
-}
-
-export class NameError extends Error {
-
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.NameError';
-        this.message = message;
-    }
-
-}
-
+// `name` is derived from the runtime class name, so subclasses don't set it
+// themselves. Apps that minify their bundles and rely on `error.name` in
+// logs or error reporting should preserve class names (e.g. esbuild
+// `keepNames`, terser `keep_classnames`).
 export class VikingError extends Error {
     constructor(message) {
         super(message);
-        this.name = 'VikingError';
+        this.name = this.constructor.name;
     }
 }
 
-export class ServerError extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'ServerError';
-    }
-}
+export class ArgumentError extends VikingError {}
 
-export class UnexpectedResponse extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'UnexpectedResponse';
-    }
-}
+export class NameError extends VikingError {}
+
+export class ServerError extends VikingError {}
+
+export class UnexpectedResponse extends VikingError {}
 
 export class BadRequest extends VikingError {
     constructor(message, response = {}) {
         super(message);
         this.response = response;
-        this.name = 'BadRequest';
     }
 }
 
-export class Unauthorized extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Unauthorized';
-    }
-}
+export class Unauthorized extends VikingError {}
 
-export class Forbidden extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Forbidden';
-    }
-}
+export class Forbidden extends VikingError {}
 
-export class NotFound extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'NotFound';
-    }
-}
+export class NotFound extends VikingError {}
 
-export class Gone extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Gone';
-    }
-}
+export class Gone extends VikingError {}
 
-export class MovedPermanently extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'MovedPermanently';
-    }
-}
+export class MovedPermanently extends VikingError {}
 
 export class UnprocessableEntity extends VikingError {
     constructor(message = 'Unprocessable Entity') {
         super(message);
-        this.name = 'UnprocessableEntity';
-        this.message = message;
     }
 }
 
-export class ApiVersionUnsupported extends VikingError {
-    constructor(message) {
+export class ApiVersionUnsupported extends VikingError {}
+
+export class ServiceUnavailable extends VikingError {}
+
+export class NetworkError extends VikingError {
+    constructor(message = 'A network error occurred') {
         super(message);
-        this.name = 'ApiVersionUnsupported';
     }
 }
 
-export class ServiceUnavailable extends VikingError {
-    constructor(message) {
+export class TimeoutError extends VikingError {
+    constructor(message = 'The request timed out') {
         super(message);
-        this.name = 'ServiceUnavailable';
     }
 }
 
-export class ConnectionNotEstablished extends VikingError {
-    constructor(message) {
+export class AbortError extends VikingError {
+    constructor(message = 'The request was aborted') {
         super(message);
-        this.name = 'ConnectionNotEstablished';
     }
 }
 
-export class ActionNotFound extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'ServerError';
-    }
-}
+export class ConnectionNotEstablished extends VikingError {}
 
-export class RecordError extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.RecordError';
-        this.message = message;
-    }
-}
+export class ActionNotFound extends VikingError {}
 
-export class RecordNotSaved extends RecordError {
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.RecordNotSaved';
-        this.message = message;
-    }
-}
+export class RecordError extends VikingError {}
 
-export class DoubleRenderError extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'DoubleRenderError';
-    }
-}
+export class RecordNotSaved extends RecordError {}
 
-export class ClassNotFound extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.ClassNotFound';
-        this.message = message;
-    }
-}
+export class DoubleRenderError extends VikingError {}
 
-export class NotImplementedError extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.NotImplementedError';
-        this.message = message;
-    }
-}
+export class ClassNotFound extends VikingError {}
 
-export class ConnectionMismatch extends VikingError {
-    constructor(message) {
-        super(message);
-        this.name = 'Viking.ConnectionMismatch';
-        this.message = message;
-    }
-}
+export class NotImplementedError extends VikingError {}
+
+export class ConnectionMismatch extends VikingError {}

--- a/lib/viking/record/abstract-connection.js
+++ b/lib/viking/record/abstract-connection.js
@@ -356,9 +356,9 @@ export default class AbstractConnection {
         // There was a connection error of some sort
         // The `error`, `abort`, `timeout`, and `load` events are mutually
         // exclusive. Only one of them may happen.
-        request.addEventListener('error', reject);
-        request.addEventListener('abort', reject);
-        request.addEventListener('timeout', reject);
+        request.addEventListener('error', () => reject(new Errors.NetworkError()));
+        request.addEventListener('abort', () => reject(new Errors.AbortError()));
+        request.addEventListener('timeout', () => reject(new Errors.TimeoutError()));
         
         if(progress) {
             request.addEventListener('progress', progress);

--- a/test/record/abstractConnectionTest.js
+++ b/test/record/abstractConnectionTest.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import * as Errors from 'viking/errors';
 import AbstractConnection from 'viking/record/abstract-connection';
 import VikingRecord from 'viking/record';
 import Types from 'viking/record/types';
@@ -366,6 +367,53 @@ describe('Viking.Record', () => {
                 );
 
                 this.withRequest('GET', '/', {}, (xhr) => xhr.respond(422, {}, ''));
+            });
+        });
+
+        describe('transport failures', () => {
+            it('rejects a network error with NetworkError', function (done) {
+                let connection = new AbstractConnection('http://example.com');
+
+                connection.get('/').then(
+                    () => done(new Error('expected rejection')),
+                    (error) => {
+                        assert.ok(error instanceof Error);
+                        assert.ok(error instanceof Errors.NetworkError);
+                        done();
+                    }
+                );
+
+                this.withRequest('GET', '/', {}, (xhr) => xhr.error());
+            });
+
+            it('rejects an abort with AbortError', function (done) {
+                let connection = new AbstractConnection('http://example.com');
+
+                connection.get('/').then(
+                    () => done(new Error('expected rejection')),
+                    (error) => {
+                        assert.ok(error instanceof Error);
+                        assert.ok(error instanceof Errors.AbortError);
+                        done();
+                    }
+                );
+
+                this.withRequest('GET', '/', {}, (xhr) => xhr.abort());
+            });
+
+            it('rejects a timeout with TimeoutError', function (done) {
+                let connection = new AbstractConnection('http://example.com');
+
+                connection.get('/').then(
+                    () => done(new Error('expected rejection')),
+                    (error) => {
+                        assert.ok(error instanceof Error);
+                        assert.ok(error instanceof Errors.TimeoutError);
+                        done();
+                    }
+                );
+
+                this.withRequest('GET', '/', {}, (xhr) => xhr.triggerTimeout());
             });
         });
 


### PR DESCRIPTION
## What

Rejects XHR transport failures (`error`, `abort`, `timeout`) with proper `Error` instances instead of the raw DOM `ProgressEvent`, and simplifies the error class definitions in `errors.js`.

## Why

A downstream app hit Sentry issue INTEL-JS-11 (`ProgressEvent (type=error) captured as promise rejection`). `sendRequest` in `abstract-connection.js` wired transport failures as:

```js
request.addEventListener('error', reject);
request.addEventListener('abort', reject);
request.addEventListener('timeout', reject);
```

Passing reject directly as the DOM listener means any network-level failure rejects the promise with the ProgressEvent object rather than an Error — so downstream .catch() handlers and error reporters receive an event, not an error. Routing these through the existing errorForResponse wasn't an option since request.status is 0 for all three, which would collapse them into the generic "Unexpected response status 0".

Changes

- lib/viking/record/abstract-connection.js — the three listeners now reject with NetworkError, AbortError, and TimeoutError respectively. The events are mutually exclusive with load, so together with the existing load handler every terminal XHR outcome now settles the promise with a proper value (no loadend listener needed — it's a post-hoc cleanup hook, not a fifth outcome).
- lib/viking/errors.js — added the three new classes, and refactored the file:
  - VikingError now sets this.name = this.constructor.name, so subclasses no longer assign name individually; most collapsed to one-liners. (Apps that minify and rely on error.name should preserve class names, e.g. esbuild keepNames.)
  - Dropped the inconsistent Viking. name prefixes (Viking.RecordError → RecordError, etc.).
  - ArgumentError and NameError now extend VikingError instead of Error directly.
  - Fixed ActionNotFound misreporting its name as ServerError (copy-paste bug).

Compatibility

- No code in lib/ or test/ branches on the rejection value's type or the old namespaced name strings (verified by grep).
- Relation#load distinguishes intentional aborts by request identity (controlledAborts), not error type, so aborts rejecting with AbortError is safe.

Tests

Added a transport failures block to abstractConnectionTest.js — the first tests simulating network-level failures (via sinon's fake XHR error(), abort(), and triggerTimeout()), asserting each rejection is an Error of the right class. Full suite: 901 passing.