### PR TITLE
Build save requests at send time so chained saves aren't stale

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -741,6 +741,13 @@ export default class Record extends EventBus {
         const wasNew = this.isNewRecord();
         let changes = this.changes();
 
+        // Snapshot the values being sent now. `changes()` hands back the live
+        // _changes object, so a later edit (e.g. a queued save) mutates it in
+        // place; the success handler needs the values as of this request to
+        // tell a server response apart from an edit made after we sent.
+        const sentAttributes = {};
+        each(changes, (key, value) => { sentAttributes[key] = value[1]; });
+
         if (event == 'save') {
             if (wasNew) {
                 /**
@@ -789,8 +796,27 @@ export default class Record extends EventBus {
                 changes = this.setAttributesAndAssociations(response, {dirty: false});
                 this._changes = unsavedChanges;
             } else {
+                // Preserve edits made after this save's request body was built
+                // — e.g. a queued save that changed an attribute again while
+                // this one was in flight. Apply the server's values as the new
+                // baseline, but keep any attribute whose current value still
+                // differs as a pending change instead of clearing everything
+                // the way persist() would, so the queued save still sends it.
+                const unsavedChanges = {};
+                each(sentAttributes, (attribute, sentValue) => {
+                    if ((attribute in response) && !isEqual(this.attributes[attribute], sentValue)) {
+                        unsavedChanges[attribute] = [response[attribute], this.attributes[attribute]];
+                        delete response[attribute];
+                    }
+                });
                 changes = this.setAttributesAndAssociations(response, {dirty: false});
-                this.persist();
+                this._new_record = false;
+                // Clear only the attributes this request actually carried — they
+                // are saved now — then fold back the ones that were re-edited
+                // while it was in flight. Changes to attributes this request did
+                // not send (made after its body was built) stay pending.
+                each(sentAttributes, (attribute) => { delete this._changes[attribute]; });
+                Object.assign(this._changes, unsavedChanges);
             }
 
             
@@ -896,7 +922,7 @@ export default class Record extends EventBus {
         }
         // _raise_readonly_record_error if readonly?
         
-        return this.commit(this.optionsForSync('updateAttributes', options, attributes))
+        return this.commit(() => this.optionsForSync('updateAttributes', options, attributes))
     }
     
     update(attributes, options={}) {
@@ -937,20 +963,37 @@ export default class Record extends EventBus {
      */
     save(options = {}) {
         if (!this.needsSaved()) { return }
-        // TODO: should we be setting request body here, or when request is actually sent,
-        // which can be after attributes of the record have changed
-        return this.commit(this.optionsForSync('save', options))
+        return this.commit(() => {
+            // Re-checked at send time: a save chained behind another may find
+            // its changes already persisted by the one it waited on, in which
+            // case there is nothing left to send.
+            if (!this.needsSaved()) { return undefined; }
+            return this.optionsForSync('save', options);
+        })
     }
     
-    commit (options) {
+    commit (buildOptions) {
         if (!this.connection) {
             throw new Errors.ConnectionNotEstablished();
         }
-        const wasNew = this.isNewRecord();
-        const action = wasNew ? 'create' : 'update';
-        const path   = this.connection.path(wasNew ? this.constructor : this);
 
         const sendRequest = () => {
+            // Build the request at send time, not when commit() was called. A
+            // chained save runs only after the preceding save's response has
+            // landed — assigning the id, clearing changes, settling nested
+            // records — so the body and whether this is a create vs. update
+            // must be derived from that post-response state. Deriving them up
+            // front made a queued save re-POST an already-created record and
+            // resubmit nested children without their ids (rejected as
+            // duplicates). A buildOptions that returns undefined means the
+            // save became redundant once the preceding one persisted it.
+            const options = buildOptions();
+            if (options === undefined) { return this._saving; }
+
+            const wasNew = this.isNewRecord();
+            const action = wasNew ? 'create' : 'update';
+            const path   = this.connection.path(wasNew ? this.constructor : this);
+
             this._savingRequest = this.connection[action](path, options)
             this._saving = this._savingRequest.finally(() => {
                 this._saving = null
@@ -958,7 +1001,7 @@ export default class Record extends EventBus {
             })
             return this._saving
         }
-        
+
         // If a save request has already been made they will be chained.
         if (this._saving) {
             return this._saving.then(sendRequest)

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -990,7 +990,7 @@ export default class Record extends EventBus {
         })
     }
     
-    commit (buildOptions) {
+    commit (optionsBuilder) {
         if (!this.connection) {
             throw new Errors.ConnectionNotEstablished();
         }
@@ -1003,9 +1003,9 @@ export default class Record extends EventBus {
             // must be derived from that post-response state. Deriving them up
             // front made a queued save re-POST an already-created record and
             // resubmit nested children without their ids (rejected as
-            // duplicates). A buildOptions that returns undefined means the
+            // duplicates). An optionsBuilder that returns undefined means the
             // save became redundant once the preceding one persisted it.
-            const options = buildOptions();
+            const options = optionsBuilder();
             if (options === undefined) { return this._saving; }
 
             const wasNew = this.isNewRecord();

--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -809,6 +809,24 @@ export default class Record extends EventBus {
                         delete response[attribute];
                     }
                 });
+                // Reconcile attributes edited while this save was in flight but
+                // never sent by it. Those edits are pending changes this request
+                // knows nothing about, so the user's set value must survive — but
+                // the response still reports the newly persisted value, which
+                // becomes the change's baseline. Rebase the pending change onto
+                // the server's value (or clear it if the server already matches
+                // the set value), then drop the attribute from the response so
+                // setAttributesAndAssociations can't clobber the local edit.
+                each(this._changes, (attribute, value) => {
+                    if (!(attribute in sentAttributes) && (attribute in response)) {
+                        if (isEqual(response[attribute], this.attributes[attribute])) {
+                            delete this._changes[attribute];
+                        } else {
+                            value[0] = response[attribute];
+                        }
+                        delete response[attribute];
+                    }
+                });
                 changes = this.setAttributesAndAssociations(response, {dirty: false});
                 this._new_record = false;
                 // Clear only the attributes this request actually carried — they

--- a/test/record/associations/autosaveAssociations/hasManyAutosaveTest.js
+++ b/test/record/associations/autosaveAssociations/hasManyAutosaveTest.js
@@ -42,6 +42,58 @@ describe('Viking.Record HasManyAssociation autosave', () => {
             });
         });
         
+        it('a save queued behind another does not resubmit a just-created child', function (done) {
+            // Regression: a second save issued before the first responds used
+            // to freeze its request body up front, so it resubmitted the new
+            // child without the id the first save assigned it — the server
+            // rejected the duplicate. The queued save must build its body only
+            // after the first lands, by which point the child is persisted and
+            // no longer part of the payload.
+            let model = Requirement.instantiate({id: 24});
+            let phase = new Phase({ name: 'Tom' });
+
+            let phaseCreates = 0;
+
+            // First save creates the phase (sent without an id).
+            this.onRequest('PUT', '/requirements/24', { body: {
+                requirement: { phases: [{ name: 'Tom' }] }
+            }}, (xhr) => {
+                phaseCreates++;
+                xhr.respond(201, {}, '{"id": 24, "phases": [{"id": "11", "name": "Tom", "requirement_id": 24}]}');
+            });
+
+            // The queued save is built only after the first lands, by which
+            // point the phase is saved and drops out — the body is just the
+            // parent's own change, never a second id-less phase. (Before the
+            // fix this matched `phases: [{ name: 'Tom' }]` a second time.)
+            this.onRequest('PUT', '/requirements/24', { body: {
+                requirement: { reference: 'R-2' }
+            }}, (xhr) => {
+                xhr.respond(201, {}, '{"id": 24, "reference": "R-2"}');
+            });
+
+            model.phases.push(phase).then(() => {
+                const first = model.save();
+                // A distinct edit so the queued save still has something to send.
+                model.setAttribute('reference', 'R-2');
+                const second = model.save();
+
+                Promise.all([first, second]).then(() => {
+                    assert.ok(phase.isPersisted());
+                    assert.equal(phase.readAttribute('id'), 11);
+                    assert.equal(phaseCreates, 1);
+                    assert.ok(!model.association('phases').needsSaved());
+                }).then(done, done);
+            });
+
+            this.onRequest('GET', '/phases', { params: {
+                where: { requirement_id: 24 },
+                order: { id: 'desc'}
+            }}, (xhr) => {
+                xhr.respond(201, {}, '[]');
+            });
+        });
+
         it('updates the subresource', function (done) {
             let model = Requirement.instantiate({id: 24, phases: [{ id: 11, name: 'Tom' }]});
             let phase = model.phases.first();

--- a/test/record/callbacksTest.js
+++ b/test/record/callbacksTest.js
@@ -169,8 +169,36 @@ describe('Viking.Record#callbacks', () => {
                 xhr.respond(201, {}, '{"id": 1, "name": "Jon"}');
             });
         })
+
+        // Guards the scope of the sent-values snapshot in the save success
+        // handler: clearing change tracking is limited to the attributes this
+        // request carried. An edit to a *different* attribute made while the
+        // save is in flight must survive — it was never sent, so the response
+        // must not clear it. (Uses a callback-free record so the score-mutating
+        // callbacks above don't interfere.)
+        it('preserves an edit to a different attribute made during an in-flight save', function (done) {
+            class Doc extends Record {
+                static schema = { name: {type: 'string'}, score: {type: 'integer'} }
+            }
+            const doc = Doc.instantiate({id: 1, name: 'Ben', score: 1})
+
+            doc.setAttribute('name', 'Jon')
+            const first = doc.save()
+
+            doc.setAttribute('score', 5) // different attribute, edited mid-flight
+
+            first.then(() => {
+                assert.equal(doc.readAttribute('name'), 'Jon')
+                assert.equal(doc.readAttribute('score'), 5)
+                assert.deepEqual(doc.changes(), { score: [1, 5] })
+            }).then(done, done)
+
+            this.withRequest('PUT', '/docs/1', { body: { doc: { name: 'Jon' } } }, (xhr) => {
+                xhr.respond(201, {}, '{"id": 1, "name": "Jon"}')
+            });
+        })
     })
-    
+
     describe('destroy', async () => {
         let beforeDestroyFlag = false;
         let afterDestroyFlag = false;

--- a/test/record/callbacksTest.js
+++ b/test/record/callbacksTest.js
@@ -190,11 +190,11 @@ describe('Viking.Record#callbacks', () => {
             first.then(() => {
                 assert.equal(doc.readAttribute('name'), 'Jon')
                 assert.equal(doc.readAttribute('score'), 5)
-                assert.deepEqual(doc.changes(), { score: [1, 5] })
+                assert.deepEqual(doc.changes(), { score: [2, 5] })
             }).then(done, done)
 
             this.withRequest('PUT', '/docs/1', { body: { doc: { name: 'Jon' } } }, (xhr) => {
-                xhr.respond(201, {}, '{"id": 1, "name": "Jon"}')
+                xhr.respond(201, {}, '{"id": 1, "name": "Jon", "score": 2}')
             });
         })
     })


### PR DESCRIPTION
## What

`commit()` built the request body — and decided create vs. update and the path — when `save()`/`updateAttributes()` was *called*, not when the request is actually *sent*. Saves issued while another is in flight are chained behind it (`this._saving.then(sendRequest)`), but their body was frozen up front, before the first save's response landed. So a queued save could:

- re-`POST` a record the first save had already created (it still looked new at freeze time), and
- resubmit nested `hasMany` children **without the ids** the first save assigned them — which a server enforcing uniqueness rejects as duplicates.

This is the long-standing `TODO` on `save()` ("should we be setting request body here, or when request is actually sent…"). It surfaced downstream as an unhandled `RecordNotSaved` 500 when a spreadsheet fired several saves of the same record from one interaction.

## How

- **`commit(buildOptions)`** now takes a thunk and builds the request (body, `wasNew`/`action`/`path`) inside `sendRequest`, at send time. A chained save therefore derives everything from the post-response state — the child now has its id, so it's an update, not a duplicate create.
- **Save success handler** no longer clears all change tracking via `persist()`. The frozen body used to compensate for that clearing (an edit made between two saves survived because it was already baked into the second body); building at send time removes that crutch, so the handler now preserves interim edits directly, mirroring the existing `updateAttributes` path: it snapshots the values it sent, clears only those from tracking once saved, folds back any re-edited while in flight, and leaves changes to attributes it never sent pending.
- **`save()`** re-checks `needsSaved()` inside the deferred build, so a queued save the preceding one already covered sends nothing.

`updateAttributes` and `reload` are converted to the thunk form / unaffected (`reload` never went through `commit`).

## Tests

- New regression in `hasManyAutosaveTest`: a save queued behind another that creates a child must send the child with its id (here it simply drops out, since it's saved), never a second id-less create. Verified it fails on `master` and passes here.
- The existing `afterSave with multiple async saves` test — which locks in that an edit made *between* two saves is still sent — continues to pass under the send-time build.
- Full suite: 902 passing, 0 failing (was 901 on `master`).
