### PR TITLE
Build save requests at send time so chained saves aren't stale (simpler variant)

### DIFF
--- a/lib/viking/record.js
+++ b/lib/viking/record.js
@@ -790,7 +790,18 @@ export default class Record extends EventBus {
                 this._changes = unsavedChanges;
             } else {
                 changes = this.setAttributesAndAssociations(response, {dirty: false});
-                this.persist();
+                this._new_record = false;
+                // Clear the changes the server has now caught up to, leaving any
+                // that still differ from the persisted value pending — rather
+                // than clearing everything the way persist() would. This keeps a
+                // chained save from wiping edits it did not carry, while a value
+                // the response settled (including one the server normalized) is
+                // no longer treated as unsaved.
+                each(response, (attribute) => {
+                    if ((attribute in this._changes) && isEqual(this.attributes[attribute], response[attribute])) {
+                        delete this._changes[attribute];
+                    }
+                });
             }
 
             
@@ -896,7 +907,7 @@ export default class Record extends EventBus {
         }
         // _raise_readonly_record_error if readonly?
         
-        return this.commit(this.optionsForSync('updateAttributes', options, attributes))
+        return this.commit(() => this.optionsForSync('updateAttributes', options, attributes))
     }
     
     update(attributes, options={}) {
@@ -937,20 +948,37 @@ export default class Record extends EventBus {
      */
     save(options = {}) {
         if (!this.needsSaved()) { return }
-        // TODO: should we be setting request body here, or when request is actually sent,
-        // which can be after attributes of the record have changed
-        return this.commit(this.optionsForSync('save', options))
+        return this.commit(() => {
+            // Re-checked at send time: a save chained behind another may find
+            // its changes already persisted by the one it waited on, in which
+            // case there is nothing left to send.
+            if (!this.needsSaved()) { return undefined; }
+            return this.optionsForSync('save', options);
+        })
     }
-    
-    commit (options) {
+
+    commit (buildOptions) {
         if (!this.connection) {
             throw new Errors.ConnectionNotEstablished();
         }
-        const wasNew = this.isNewRecord();
-        const action = wasNew ? 'create' : 'update';
-        const path   = this.connection.path(wasNew ? this.constructor : this);
 
         const sendRequest = () => {
+            // Build the request at send time, not when commit() was called. A
+            // chained save runs only after the preceding save's response has
+            // landed — assigning the id, clearing changes, settling nested
+            // records — so the body and whether this is a create vs. update
+            // must be derived from that post-response state. Deriving them up
+            // front made a queued save re-POST an already-created record and
+            // resubmit nested children without their ids (rejected as
+            // duplicates). A buildOptions that returns undefined means the
+            // save became redundant once the preceding one persisted it.
+            const options = buildOptions();
+            if (options === undefined) { return this._saving; }
+
+            const wasNew = this.isNewRecord();
+            const action = wasNew ? 'create' : 'update';
+            const path   = this.connection.path(wasNew ? this.constructor : this);
+
             this._savingRequest = this.connection[action](path, options)
             this._saving = this._savingRequest.finally(() => {
                 this._saving = null
@@ -958,7 +986,7 @@ export default class Record extends EventBus {
             })
             return this._saving
         }
-        
+
         // If a save request has already been made they will be chained.
         if (this._saving) {
             return this._saving.then(sendRequest)

--- a/test/record/associations/autosaveAssociations/hasManyAutosaveTest.js
+++ b/test/record/associations/autosaveAssociations/hasManyAutosaveTest.js
@@ -42,6 +42,52 @@ describe('Viking.Record HasManyAssociation autosave', () => {
             });
         });
         
+        it('a save queued behind another does not resubmit a just-created child', function (done) {
+            // Regression: a second save issued before the first responds used
+            // to freeze its request body up front, so it resubmitted the new
+            // child without the id the first save assigned it — the server
+            // rejected the duplicate. The queued save must build its body only
+            // after the first lands, by which point the child is persisted and
+            // no longer part of the payload.
+            let model = Requirement.instantiate({id: 24});
+            let phase = new Phase({ name: 'Tom' });
+
+            let phaseCreates = 0;
+
+            this.onRequest('PUT', '/requirements/24', { body: {
+                requirement: { phases: [{ name: 'Tom' }] }
+            }}, (xhr) => {
+                phaseCreates++;
+                xhr.respond(201, {}, '{"id": 24, "phases": [{"id": "11", "name": "Tom", "requirement_id": 24}]}');
+            });
+
+            this.onRequest('PUT', '/requirements/24', { body: {
+                requirement: { reference: 'R-2' }
+            }}, (xhr) => {
+                xhr.respond(201, {}, '{"id": 24, "reference": "R-2"}');
+            });
+
+            model.phases.push(phase).then(() => {
+                const first = model.save();
+                model.setAttribute('reference', 'R-2');
+                const second = model.save();
+
+                Promise.all([first, second]).then(() => {
+                    assert.ok(phase.isPersisted());
+                    assert.equal(phase.readAttribute('id'), 11);
+                    assert.equal(phaseCreates, 1);
+                    assert.ok(!model.association('phases').needsSaved());
+                }).then(done, done);
+            });
+
+            this.onRequest('GET', '/phases', { params: {
+                where: { requirement_id: 24 },
+                order: { id: 'desc'}
+            }}, (xhr) => {
+                xhr.respond(201, {}, '[]');
+            });
+        });
+
         it('updates the subresource', function (done) {
             let model = Requirement.instantiate({id: 24, phases: [{ id: 11, name: 'Tom' }]});
             let phase = model.phases.first();

--- a/test/record/callbacksTest.js
+++ b/test/record/callbacksTest.js
@@ -121,30 +121,37 @@ describe('Viking.Record#callbacks', () => {
             });
         })
         
-        it('afterSave with multiple async saves', function (done) {
-            const actor = Actor.instantiate({name: 'Ben', id: 1, score: 2})
+        // Behavioral note for this variant: a save builds its body at send
+        // time, so an attribute re-edited while a save carrying it is in flight
+        // is superseded by that save's response — the queued save finds nothing
+        // left to send. (The alternative branch preserves the newer edit and
+        // still sends it; this simpler branch does not.) Uses a callback-free
+        // record so the score-mutating callbacks above don't muddy the point.
+        it('afterSave with an attribute re-edited during an in-flight save', function (done) {
+            class Doc extends Record {
+                static schema = { name: {type: 'string'} }
+            }
+            const doc = Doc.instantiate({name: 'Ben', id: 1})
             let count = 0
-            actor.addEventListener('afterSave', (...args) => {
-                count++
-            })
-            actor.setAttribute('name', 'Jon')
-            actor.save().then((...args) => {
-                assert.equal(count, 1)
-            }).then(() => {
-                this.withRequest('PUT', '/actors/1', { body: {actor: {name: "Charlie"} } }, (xhr) => {
-                    xhr.respond(201, {}, '{"id": 1, "name": "Charlie"}');
-                });
-            })
+            doc.addEventListener('afterSave', () => { count++ })
 
-            actor.setAttribute('name', 'Charlie')
-            actor.save().then((...args) => {
-                assert.equal(count, 2)
+            doc.setAttribute('name', 'Jon')
+            const first = doc.save()
+
+            doc.setAttribute('name', 'Charlie')
+            const second = doc.save()
+
+            Promise.all([first, second]).then(() => {
+                // Only the first save reached the server; its response settled
+                // 'Jon', and the queued save had nothing left to send.
+                assert.equal(count, 1)
+                assert.equal(doc.readAttribute('name'), 'Jon')
+                assert.deepEqual(doc.changes(), {})
             }).then(done, done)
 
-            this.withRequest('PUT', '/actors/1', { body: {actor: {name: "Jon"} } }, (xhr) => {
+            this.withRequest('PUT', '/docs/1', { body: {doc: {name: "Jon"} } }, (xhr) => {
                 xhr.respond(201, {}, '{"id": 1, "name": "Jon"}');
             });
-            
         })
         
         it('afterSave with sync saves', function (done) {


### PR DESCRIPTION
Alternative to #177 — same crash fix, simpler success handler. Opening both so they can be compared.

## Shared with #177

Both branches fix the same bug: `commit()` built the request body (and decided create-vs-update and the path) when `save()` was *called*, not when it's *sent*. A save chained behind an in-flight one therefore froze stale state and could re-POST an already-created record or resubmit nested `hasMany` children without their ids (rejected as duplicates — the `RecordNotSaved` 500 seen downstream). Both branches move that work into `sendRequest` so a chained save builds from post-response state, add the same regression test, and re-check `needsSaved()` at send time so a redundant queued save sends nothing.

## The difference: what happens to an edit made *between* two saves

The frozen body used to double as a way to preserve an edit made to an attribute while a save carrying it was already in flight (that edit was baked into the second request up front). Building at send time removes that, so each branch has to decide what to do about it:

- **#177 (this is the richer one):** snapshots the values it sent and reconciles them in the success handler, so a re-edited attribute is kept pending and still sent by the queued save. The existing `afterSave with multiple async saves` test passes unchanged. ~48 lines.

- **This branch (simpler):** drops `persist()`'s blanket change-wipe and just clears the changes the server's response has caught up to; anything still differing stays pending. No sent-value snapshot. **Behavior change:** an attribute re-edited during an in-flight save is superseded by that save's response instead of being re-sent. The `afterSave with multiple async saves` test is rewritten to document that. ~30 lines.

## Trade-off

The simpler branch is less code and easier to follow, but silently drops a user edit in this sequence: edit an attribute, save, edit it again before the first save responds — the second edit is lost. In the spreadsheet that's a plausible fast type/tab/type, which is why I'd lean toward #177 — but the simpler shape may be worth it if that sequence isn't a real concern.

Both: full suite green (902 passing).
